### PR TITLE
fix csvjson utf-8 output, add output option to key json objects with a column name

### DIFF
--- a/csvjson
+++ b/csvjson
@@ -14,6 +14,8 @@ class CSVJSON(CSVKitUtility):
     def add_arguments(self):
         self.argparser.add_argument('-i', '--indent', dest='indent', type=int, default=None,
             help='Indent the output JSON this many spaces. Disabled by default.')
+        self.argparser.add_argument('-k', '--key', dest='key', type=str, default=None,
+            help='Output JSON as objects keyed by KEY. Disabled by default.')
 
     def main(self):
         """
@@ -24,7 +26,13 @@ class CSVJSON(CSVKitUtility):
 
 	stream = codecs.getwriter('utf8')(sys.stdout)
 
-        output = [dict(zip(column_names, row)) for row in rows]
+	if self.args.key:
+            output = {}
+            for row in rows:
+		row_dict = dict(zip(column_names, row))
+		output.update({row_dict[self.args.key]: row_dict})
+        else:
+            output = [dict(zip(column_names, row)) for row in rows]
 
         json.dump(output, stream, ensure_ascii=False, indent=self.args.indent, encoding='utf-8')
 


### PR DESCRIPTION
Update csvjson to output utf-8 correctly. Current code will output utf-8 like:
`"short_name_en": "\u00c5LAND ISLANDS"`
 instead of:
`"short_name_en": "ÅLAND ISLANDS"`

Also add option to output json objects keyed by a column name instead of a list.
Currently, csvjson outputs a list of dict-like JSON objects:
`csvjson -i 2 countries-of-earth.csv`

outputs:

```
[
  {
    "FIFA": "ALD", 
    "Dial": "358", 
    "ITU": " ", 
    "MARC": " ", 
    "is_independent": "Part of FI", 
    "DS": "FIN", 
    "WMO": " ", 
    "GAUL": "1242", 
    "ISO3166-1-numeric": "248", 
    "FIPS": " ", 
    "short_name_fr": "ÅLAND, ÎLES", 
    "ISO3166-1-Alpha-3": "ALA", 
    "IOC": " ", 
    "ISO3166-1-Alpha-2": "AX", 
    "short_name_en": "ÅLAND ISLANDS"
  }, 
  ...
]
```

The proposed new option accepts a named key (column name) and outputs a single dict-like JSON object where item values are the same dict-like JSON row representations that are currently outputted -- but the item names are the object's values for the given key:
`csvjson -i 2 -k ISO3166-1-Alpha-2 countries-of-earth.csv`

outputs:

```
{
  "AX": {
    "FIFA": "ALD", 
    "Dial": "358", 
    "ITU": " ", 
    "MARC": " ", 
    "is_independent": "Part of FI", 
    "DS": "FIN", 
    "WMO": " ", 
    "GAUL": "1242", 
    "ISO3166-1-numeric": "248", 
    "FIPS": " ", 
    "short_name_fr": "ÅLAND, ÎLES", 
    "ISO3166-1-Alpha-3": "ALA", 
    "IOC": " ", 
    "ISO3166-1-Alpha-2": "AX", 
    "short_name_en": "ÅLAND ISLANDS"
  }, 
   ...
}
```
