### PR TITLE
Escape quotes in insert statement generation

### DIFF
--- a/csvkit/sql.py
+++ b/csvkit/sql.py
@@ -104,9 +104,9 @@ def de_parameterize_insert_query(statement, values, dialect=None):
         elif type(v) == bool:
             return unicode(v).upper()
         elif type(v) == unicode:
-            return u'\'%s\'' % v 
+            return repr(v)[1:]
         else:
-            return unicode(v)
+            return unicode(repr(v))
 
     # ':column_name' syntax
     if dialect in ['access', 'firebird', 'maxdb', 'mssql', 'oracle', 'sybase', None]:

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -10,10 +10,10 @@ from sqlalchemy import Boolean, Date, DateTime, Float, Integer, String, Time
 class TestSQL(unittest.TestCase):
     def setUp(self):
         self.csv_table = table.Table([
-            table.Column(0, u'text', [u'Chicago Reader', u'Chicago Sun-Times', u'Chicago Tribune', u'Row with blanks']),
-            table.Column(1, u'integer', [u'40', u'63', u'164', u'']),
-            table.Column(2, u'datetime', [u'Jan 1, 2008 at 4:40 AM', u'2010-01-27T03:45:00', u'3/1/08 16:14:45', '']),
-            table.Column(3, u'empty_column', [u'', u'', u'', u''])],
+            table.Column(0, u'text', [u'Chicago Reader', u'Chicago Sun-Times', u'Chicago Tribune', u'Row with blanks', u'O\'Reilly', u'"Jeff"']),
+            table.Column(1, u'integer', [u'40', u'63', u'164', u'', u'', u'']),
+            table.Column(2, u'datetime', [u'Jan 1, 2008 at 4:40 AM', u'2010-01-27T03:45:00', u'3/1/08 16:14:45', '', u'', u'']),
+            table.Column(3, u'empty_column', [u'', u'', u'', u'', u'', u''])],
             name='test_table')
 
     def test_make_column_name(self):
@@ -81,8 +81,18 @@ u"""CREATE TABLE test_table (
 \tempty_column VARCHAR(32)
 );""")
 
-    def make_insert_statement(self):
+    def test_make_insert_statement(self):
         sql_table = sql.make_table(self.csv_table, 'csvsql')
-        statement = sql.make_insert_statement(sql_table, self.csv_table._prepare_rows_for_serialization()[0])
+        statement = sql.make_insert_statement(sql_table, self.csv_table.to_rows(serialize_dates=True)[0])
         self.assertEqual(statement, u'INSERT INTO test_table (text, integer, datetime, empty_column) VALUES (\'Chicago Reader\', 40, \'2008-01-01T04:40:00\', NULL);')
+
+    def test_make_insert_statement_with_single_quote(self):
+        sql_table = sql.make_table(self.csv_table, 'csvsql')
+        statement = sql.make_insert_statement(sql_table, self.csv_table.to_rows(serialize_dates=True)[4])
+        self.assertEqual(statement, u'INSERT INTO test_table (text, integer, datetime, empty_column) VALUES ("O\'Reilly", NULL, NULL, NULL);')
+
+    def test_make_insert_statement_with_double_quotes(self):
+        sql_table = sql.make_table(self.csv_table, 'csvsql')
+        statement = sql.make_insert_statement(sql_table, self.csv_table.to_rows(serialize_dates=True)[5])
+        self.assertEqual(statement, u'INSERT INTO test_table (text, integer, datetime, empty_column) VALUES (\'"Jeff"\', NULL, NULL, NULL);')
 


### PR DESCRIPTION
Escape quotes in insert statement generation using repr(). It also adds 2 tests with strings containing `'` and `"`.

I know this is not a fully database specific solution but IMHO I think it's better than current situation. At least it works for me :-).

I also changed in test_sql.py make_insert_statement(self) to test_make_insert_statement(self) and fix a method call from _prepare_rows_for_serialization() to to_rows(serialize_dates=True).
