### PR TITLE
Choose what quotes to use in the insert feature to avoid the need to escape

### DIFF
--- a/csvkit/sql.py
+++ b/csvkit/sql.py
@@ -104,9 +104,13 @@ def de_parameterize_insert_query(statement, values, dialect=None):
         elif type(v) == bool:
             return unicode(v).upper()
         elif type(v) == unicode:
-            return repr(v)[1:]
+            has_single_quote = '\'' in v
+            if not has_single_quote:
+                return '\'%s\'' % v
+            else:
+                return '"%s"' % v
         else:
-            return unicode(repr(v))
+            return unicode(v)
 
     # ':column_name' syntax
     if dialect in ['access', 'firebird', 'maxdb', 'mssql', 'oracle', 'sybase', None]:

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- encoding: utf-8 -*-
 
 import unittest
 
@@ -10,10 +11,10 @@ from sqlalchemy import Boolean, Date, DateTime, Float, Integer, String, Time
 class TestSQL(unittest.TestCase):
     def setUp(self):
         self.csv_table = table.Table([
-            table.Column(0, u'text', [u'Chicago Reader', u'Chicago Sun-Times', u'Chicago Tribune', u'Row with blanks', u'O\'Reilly', u'"Jeff"']),
-            table.Column(1, u'integer', [u'40', u'63', u'164', u'', u'', u'']),
-            table.Column(2, u'datetime', [u'Jan 1, 2008 at 4:40 AM', u'2010-01-27T03:45:00', u'3/1/08 16:14:45', '', u'', u'']),
-            table.Column(3, u'empty_column', [u'', u'', u'', u'', u'', u''])],
+            table.Column(0, u'text', [u'Chicago Reader', u'Chicago Sun-Times', u'Chicago Tribune', u'Row with blanks', u'O\'Reilly', u'"Jeff"', u'áéíóú']),
+            table.Column(1, u'integer', [u'40', u'63', u'164', u'', u'', u'', u'']),
+            table.Column(2, u'datetime', [u'Jan 1, 2008 at 4:40 AM', u'2010-01-27T03:45:00', u'3/1/08 16:14:45', '', u'', u'', u'']),
+            table.Column(3, u'empty_column', [u'', u'', u'', u'', u'', u'', u''])],
             name='test_table')
 
     def test_make_column_name(self):
@@ -95,4 +96,9 @@ u"""CREATE TABLE test_table (
         sql_table = sql.make_table(self.csv_table, 'csvsql')
         statement = sql.make_insert_statement(sql_table, self.csv_table.to_rows(serialize_dates=True)[5])
         self.assertEqual(statement, u'INSERT INTO test_table (text, integer, datetime, empty_column) VALUES (\'"Jeff"\', NULL, NULL, NULL);')
+
+    def test_make_insert_statement_with_utf8(self):
+        sql_table = sql.make_table(self.csv_table, 'csvsql')
+        statement = sql.make_insert_statement(sql_table, self.csv_table.to_rows(serialize_dates=True)[6])
+        self.assertEqual(statement, u'INSERT INTO test_table (text, integer, datetime, empty_column) VALUES (\'áéíóú\', NULL, NULL, NULL);')
 


### PR DESCRIPTION
Instead of escape quotes in insert statement generation it tries to use double quotes when single quote are present in the value.

It adds 2 tests with strings containing ' and " and another one to check ASCII extended characters conversion.

Finally, I also changed in test_sql.py make_insert_statement(self) to test_make_insert_statement(self) and fix a method call from _prepare_rows_for_serialization() to to_rows(serialize_dates=True).

I know this is not a fully database specific solution (see #86) but IMHO I think it's better than current situation. At least it works, for me :-).
