### PR TITLE
Limit stat output and add standard deviation

### DIFF
--- a/csvkit/utilities/csvstat.py
+++ b/csvkit/utilities/csvstat.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import datetime
+import math
 
 from csvkit import table
 from csvkit.cli import CSVKitUtility
@@ -16,58 +17,87 @@ class CSVStat(CSVKitUtility):
                             help='Limit CSV dialect sniffing to the specified number of bytes.')
         self.argparser.add_argument('-c', '--columns', dest='columns',
                         help='A comma separated list of column indices or names to be examined. Defaults to all columns.')
+        self.argparser.add_argument('--max', dest='max_only', action='store_true',
+                        help='Output will contain only max, unless there are multiple columns, in which case each value is prefixed with the column name')
+        self.argparser.add_argument('--min', dest='min_only', action='store_true',
+                        help='Output will contain only min, unless there are multiple columns, in which case each value is prefixed with the column name')
+        self.argparser.add_argument('--sum', dest='sum_only', action='store_true',
+                        help='Output will contain only sum, unless there are multiple columns, in which case each value is prefixed with the column name')
+        self.argparser.add_argument('--mean', dest='mean_only', action='store_true',
+                        help='Output will contain only mean, unless there are multiple columns, in which case each value is prefixed with the column name')
+        self.argparser.add_argument('--median', dest='median_only', action='store_true',
+                        help='Output will contain only median, unless there are multiple columns, in which case each value is prefixed with the column name')
+        self.argparser.add_argument('--stdev', dest='stdev_only', action='store_true',
+                        help='Output will contain only standard deviation, unless there are multiple columns, in which case each value is prefixed with the column name')
 
     def main(self):
         tab = table.Table.from_csv(self.args.file, snifflimit=self.args.snifflimit, column_ids=self.args.columns, **self.reader_kwargs)
 
+        limit_keys = ('min', 'max', 'sum', 'mean', 'median', 'stdev')
+        selected_keys = [k for k in limit_keys if getattr(self.args, k+'_only')]
         for c in tab:
-            uniques = set(c)
-            uniques.discard(None)
-
-            self.output_file.write((u'%3i. %s\n' % (c.order + 1, c.name)).encode('utf-8'))
-
-            if c.type == None:
-                self.output_file.write(u'\tEmpty column\n')
-                continue
-                
-            self.output_file.write(u'\t%s\n' % c.type)
-            self.output_file.write(u'\tNulls: %s\n' % (u'Yes' if c.nullable else u'No'))
-            
-            if len(uniques) <= 5 and c.type is not bool:
-                uniques = [unicode(u) for u in list(uniques)]
-                self.output_file.write((u'\tValues: %s\n' % ', '.join(uniques)).encode('utf-8'))
-            else:
+            # WARNING: observe the correlation in naming against the argparse targets.
+            maxval = minval = meanval = medialval = stdevval = None
+            # Skip stats such as min/max for strings and bools
+            # WARNING: observe the symmetry in the first two type checks with another block at the end.
+            if c.type not in [unicode, bool] and c:
                 values = sorted(filter(lambda i: i is not None, c))
+                minval = min(values)
+                maxval = max(values)
+                if c.type in [int, float]:
+                    sumval = sum(values)
+                    meanval = float(sumval) / len(values)
+                    medianval = median(values)
+                    stdevval = math.sqrt(sum(math.pow(v-meanval, 2) for v in values) / len(values))
+                if c.type in [datetime.datetime, datetime.date, datetime.time]:
+                    minval = minval.isoformat()
+                    maxval = maxval.isoformat()
+
+            if selected_keys:
+                # If multiple options are chosen, always choose the first selected option.
+                val = locals()[selected_keys[0]+'val']
+                self.output_file.write(u'%s%s' % (len(tab) != 1 and c.name+': ' or '', val and str(val)+'\n' or ''))
+            else:
+                uniques = set(c)
+                uniques.discard(None)
+
+                self.output_file.write((u'%3i. %s\n' % (c.order + 1, c.name)).encode('utf-8'))
+
+                if c.type == None:
+                    self.output_file.write(u'\tEmpty column\n')
+                    continue
+                    
+                self.output_file.write(u'\t%s\n' % c.type)
+                self.output_file.write(u'\tNulls: %s\n' % (u'Yes' if c.nullable else u'No'))
                 
-                # Skip min/max for strings and bools
-                if c.type not in [unicode, bool]:
-                    minval = min(values)
-                    maxval = max(values)
+                if len(uniques) <= 5 and c.type is not bool:
+                    uniques = [unicode(u) for u in list(uniques)]
+                    self.output_file.write((u'\tValues: %s\n' % ', '.join(uniques)).encode('utf-8'))
+                else:
+                    # Skip stats such as min/max for strings and bools
+                    # WARNING: observe the symmetry in the type checks with another block at the beginning.
+                    if c.type not in [unicode, bool]:
+                        self.output_file.write(u'\tMin: %s\n' % minval)
+                        self.output_file.write(u'\tMax: %s\n' % maxval)
+                        if c.type in [int, float]:
+                            self.output_file.write(u'\tSum: %s\n' % sumval)
+                            self.output_file.write(u'\tMean: %s\n' % meanval)
+                            self.output_file.write(u'\tMedian: %s\n' % medianval)
+                            self.output_file.write(u'\tStandard Deviation: %s\n' % stdevval)
 
-                    if c.type in [datetime.datetime, datetime.date, datetime.time]:
-                        minval = minval.isoformat()
-                        maxval = maxval.isoformat()
+                    self.output_file.write(u'\tUnique values: %i\n' % len(uniques))
 
-                    self.output_file.write(u'\tMin: %s\n' % min(values))
-                    self.output_file.write(u'\tMax: %s\n' % max(values))
+                    if len(uniques) != len(values):
+                        self.output_file.write(u'\t5 most frequent values:\n')
+                        for value, count in freq(values):
+                            self.output_file.write((u'\t\t%s:\t%s\n' % (unicode(value), count)).encode('utf-8'))
 
-                    if c.type in [int, float]:
-                        self.output_file.write(u'\tSum: %s\n' % sum(values))
-                        self.output_file.write(u'\tMean: %s\n' % (sum(values) / len(values)))
-                        self.output_file.write(u'\tMedian: %s\n' % median(values))
+                    if c.type == unicode:
+                        self.output_file.write(u'\tMax length: %i\n' % c.max_length)
 
-                self.output_file.write(u'\tUnique values: %i\n' % len(uniques))
-
-                if len(uniques) != len(values):
-                    self.output_file.write(u'\t5 most frequent values:\n')
-                    for value, count in freq(values):
-                        self.output_file.write((u'\t\t%s:\t%s\n' % (unicode(value), count)).encode('utf-8'))
-
-                if c.type == unicode:
-                    self.output_file.write(u'\tMax length: %i\n' % c.max_length)
-
-        self.output_file.write(u'\n')
-        self.output_file.write(u'Row count: %s\n' % tab.count_rows())
+        if not selected_keys:
+            self.output_file.write(u'\n')
+            self.output_file.write(u'Row count: %s\n' % tab.count_rows())
 
 def median(l):
     """


### PR DESCRIPTION
Before I found csvkit, I used to frequently pipe columns (using `"cut -d, -f"`) to awk (with something like `awk {sum += $0;} END {print sum;}`), so I wanted similar functionality with csvkit. Basically, I added options such as `--sum` that only print the requested stat. This is very useful for further processing, especially when there is only a single column, as you could do command substitution in scripts.

I also added "standard deviation" to the set of stats printed.
