### PR TITLE
Fix for the fact that some versions of the csv module (apparently

### DIFF
--- a/csvkit/unicsv.py
+++ b/csvkit/unicsv.py
@@ -6,6 +6,7 @@ This module contains unicode aware replacements for :func:`csv.reader` and :func
 
 import codecs
 import csv
+import fnmatch
 from cStringIO import StringIO
 
 from csvkit.exceptions import FieldSizeLimitError
@@ -40,7 +41,7 @@ class UnicodeCSVReader(object):
             row = self.reader.next()
         except csv.Error, e:
             # Terrible way to test for this exception, but there is no subclass
-            if 'field larger than field limit' in str(e):
+            if fnmatch.fnmatch(str(e), 'field large[rt] than field limit *'):
                 raise FieldSizeLimitError(csv.field_size_limit())
             else:
                 raise e


### PR DESCRIPTION
including some bundled with pypy) misspell the word "larger" as
"larget". This fixes one pypy test failure mentioned in GH-165.
