### PR TITLE
Add a setup.cfg file that tells nosetests to ignore dbf.py.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+ignore-files=dbf.py


### PR DESCRIPTION
This fixes GH-169 for me.
