### PR TITLE
Fix encoding-related test failure ("TypeError: expected string...

### DIFF
--- a/tests/test_convert/test_dbf.py
+++ b/tests/test_convert/test_dbf.py
@@ -5,6 +5,9 @@ import unittest
 from csvkit.convert import dbase
 
 class TestDBF(unittest.TestCase):
+    def setUp(self):
+        dbase.dbf.input_decoding = 'utf-8'
+
     def test_dbf(self):
         with open('examples/testdbf.dbf', 'rb') as f:
             output = dbase.dbf2csv(f)


### PR DESCRIPTION
Fix encoding-related test failure (`TypeError: expected string, got NoneType object`) in `test_dbf.py`. It is a replacement for the bad approach in #171.
