### PR TITLE
Make csvlook output compatible with emacs org-mode table markup

### DIFF
--- a/csvkit/utilities/csvlook.py
+++ b/csvkit/utilities/csvlook.py
@@ -24,8 +24,9 @@ class CSVLook(CSVKitUtility):
                 except IndexError:
                     widths.append(len(v))
 
-        # Width of the fields, plus space between, plus fore and aft dividers 
-        divider = '-' * (sum(widths) + (3 * len(widths)) + 3)
+        # Dashes span each width with '+' character at intersection of
+        # horizontal and vertical dividers.
+        divider = '|--' + '-+-'.join('-'* w for w in widths) + '--|'
 
         self.output_file.write('%s\n' % divider)
 


### PR DESCRIPTION
This is a one-line change in csvlook that adds '+' characters to the horizontal divider at the intersection with vertical column separators. As a result, the output is compatible with emacs org-mode table markup and can be inserted directly into org-mode documents, rendered into other media using org-export, etc.
