### PR TITLE
Allow specified tabs to be converted in xlsx converter

### DIFF
--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -36,7 +36,11 @@ def xlsx2csv(f, output=None, **kwargs):
     writer = CSVKitWriter(output)
 
     book = load_workbook(f, use_iterators=True)
-    sheet = book.get_active_sheet()
+    if 'sheet' in kwargs:
+        sheetn = kwargs['sheet']
+        sheet = book.get_sheet_by_name(sheetn)
+    else:
+        sheet = book.get_active_sheet()
 
     for i, row in enumerate(sheet.iter_rows()):
         if i == 0:


### PR DESCRIPTION
xlsx2csv now handles a "sheet" named argument. If it not specified then the default tab is used as before.
