### PR TITLE
Let in2csv step over null rows in xlsx files

### DIFF
--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -60,6 +60,9 @@ def xlsx2csv(f, output=None, **kwargs):
             if value.__class__ in (datetime.datetime, datetime.date, datetime.time):
                 value = value.isoformat()
 
+            if value == "\0":
+                continue
+
             out_row.append(value)
 
         writer.writerow(out_row)


### PR DESCRIPTION
i'm using csvkit to process emailed excel files, but i keep encountering xlsx files with null rows, and in2csv output bails when the null is encountered.

this patch is saving me grief, so i thought i'd offer it. i tried writing a test for it but got deep in weeds trying to replicate the bad xlsx content. 

i haven't hit this issue (or been able to replicate it) with the older xls format.
