### PR TITLE
Read csvgrep's matchfile into a set instead of a list for better lookup performance.

### DIFF
--- a/csvkit/utilities/csvgrep.py
+++ b/csvkit/utilities/csvgrep.py
@@ -44,7 +44,7 @@ class CSVGrep(CSVKitUtility):
         if self.args.regex:
             pattern = re.compile(self.args.regex)
         elif self.args.matchfile:
-            lines = {line.rstrip() for line in self.args.matchfile}
+            lines = set(line.rstrip() for line in self.args.matchfile)
             pattern = lambda x: x in lines
         else:
             pattern = self.args.pattern


### PR DESCRIPTION
Tested with the following command which before, took over a few minutes (I ended up killing it, not sure how long it would take). After changing to using a set, it finishes in ~2 seconds for me:

csvgrep -c 1 -f /usr/share/dict/words /usr/share/dict/words
