### PR TITLE
Resolve crash in normalize_datetime

### DIFF
--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -17,7 +17,7 @@ def normalize_datetime(dt):
     if ms < 1000:
         return dt.replace(microsecond=0)
     elif ms > 999000:
-        return dt.replace(second=dt.second + 1, microsecond=0)
+        return dt.replace(microsecond=0) + datetime.timedelta(seconds=1)
 
     return dt
 

--- a/tests/test_convert/test_xlsx.py
+++ b/tests/test_convert/test_xlsx.py
@@ -3,6 +3,7 @@
 import unittest
 
 from csvkit.convert import xlsx
+from datetime import datetime
 
 class TestXLSX(unittest.TestCase):
     def test_xlsx(self):
@@ -18,3 +19,20 @@ class TestXLSX(unittest.TestCase):
 
         with open('examples/sheetsxlsx_converted.csv', 'r') as f:
             self.assertEquals(f.read(), output)
+
+    def test_normalize_datetime(self):
+        dt = datetime(2013, 8, 22, 9, 51, 59, 999001)
+        self.assertEqual(datetime(2013, 8, 22, 9, 52, 0), xlsx.normalize_datetime(dt))
+
+        dt = datetime(2013, 8, 22, 9, 51, 58, 999001)
+        self.assertEqual(datetime(2013, 8, 22, 9, 51, 59), xlsx.normalize_datetime(dt))
+
+        dt = datetime(2013, 8, 22, 9, 51, 59, 0)
+        self.assertEqual(dt, xlsx.normalize_datetime(dt))
+
+        dt = datetime(2013, 8, 22, 9, 51, 59, 999)
+        self.assertEqual(datetime(2013, 8, 22, 9, 51, 59, 0), xlsx.normalize_datetime(dt))
+
+        dt = datetime(2013, 8, 22, 9, 51, 59, 5000)
+        self.assertEqual(dt, xlsx.normalize_datetime(dt))
+


### PR DESCRIPTION
Normalize_datetime would crash when a datetime had more than 999,000 microseconds and the seconds was already at 59.  This fixes that.
