### PR TITLE
argparse is defined as a requirement only for python versions < 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python
 
+import sys
 from setuptools import setup
+
+install_requires = [
+    'xlrd>=0.7.1',
+    'python-dateutil>=1.5',
+    'sqlalchemy>=0.6.6',
+    'openpyxl>=1.5.7',
+    'dbf>=0.94.003']
+
+if sys.version_info < (2, 7):
+    install_requires.append('argparse>=1.2.1')
 
 setup(
     name='csvkit',
@@ -27,7 +38,7 @@ setup(
         'Topic :: Utilities'
     ],
     packages=[
-        'csvkit', 
+        'csvkit',
         'csvkit.convert',
         'csvkit.utilities'
     ],
@@ -47,11 +58,5 @@ setup(
             'csvpy = csvkit.utilities.csvpy:launch_new_instance'
         ]
     },
-    install_requires = [
-        'argparse>=1.2.1',
-        'xlrd>=0.7.1',
-        'python-dateutil>=1.5',
-        'sqlalchemy>=0.6.6',
-        'openpyxl>=1.5.7',
-        'dbf>=0.94.003']
+    install_requires = install_requires
 )


### PR DESCRIPTION
Fixes issue where installation of argparse under python 2.7 causes "argparse was already imported from ..." warning under some circumstances.
