### PR TITLE
Add "python setup.py develop" to developer install steps.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ For developers::
     cd csvkit
     mkvirtualenv --no-site-packages csvkit
     pip install -r requirements.txt
+    python setup.py develop
     nosetests
 
 .. note::


### PR DESCRIPTION
Currently instructions are as follows:

``` bash
git clone git://github.com/onyxfish/csvkit.git
cd csvkit
mkvirtualenv --no-site-packages csvkit
pip install -r requirements.txt
nosetests
```

This successfully runs the tests, but even in the csvkit environment that we create `csvcut` and friends aren't available in the path. I tried to run the scripts directly, but got this error:

``` bash
python ./csvkit/utilities/csvcut.py
#    Traceback (most recent call last):
#      File "./csvkit/utilities/csvcut.py", line 14, in <module>
#        from csvkit import CSVKitReader, CSVKitWriter
#    ImportError: No module named csvkit
```

After a bit of googling around, I realized the following is a fix:

``` bash
python setup.py develop
#    symlinks ~/.virtualenvs/csvkit/bin/csvcut and friends
```

This pull request adds this command to the instructions, which will make it much easier to dive into debugging without knowing the intricacies of virtualenv.
