### PR TITLE
--no-header-row or -N was not compatible with specifying specific columns with -c

### DIFF
--- a/csvkit/table.py
+++ b/csvkit/table.py
@@ -207,7 +207,8 @@ class Table(list):
             row = next(rows) 
 
             headers = make_default_headers(len(row))
-            column_ids = range(len(row))
+            column_ids = parse_column_identifiers(column_ids, headers, zero_based)
+            headers = [headers[c] for c in column_ids]
             data_columns = [[] for c in headers]
 
             # Put row back on top


### PR DESCRIPTION
this can be tested via:

jot - 1 100 | column | perl -pe "s/[\t ]+/ /g" | python -m csvkit.utilities.csvstat -d ' ' -c 1 -H
