### PR TITLE
Bugfix to make sure that csvkit installs with all indexes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='csvkit',
-    version='0.6.2',
+    version='0.6.3',
     description='A library of utilities for working with CSV, the king of tabular file formats.',
     long_description=open('README').read(),
     author='Christopher Groskopf',
@@ -51,7 +51,7 @@ setup(
         'argparse>=1.2.1',
         'xlrd>=0.7.1',
         'python-dateutil>=1.5',
-        'sqlalchemy>=0.6.6',
+        'SQLAlchemy>=0.6.6',
         'openpyxl>=1.5.7',
         'dbf>=0.94.003']
 )


### PR DESCRIPTION
pypi.python.org currently adds make to allow full lowercase installs.  Web servers are case sensitive by default, however, so in many instances where you're running a custom index, the `sqlalchemy` dependency won't be found.
