### PR TITLE
Fixed Travis CI link

### DIFF
--- a/README
+++ b/README
@@ -8,4 +8,4 @@ Important links:
 * Issues:        https://github.com/onyxfish/csvkit/issues
 * Documentation: http://csvkit.rtfd.org/
 * Schemas:       https://github.com/onyxfish/ffs
-* Buildbot:      http://travis-ci.org/#!/onyxfish/csvkit
+* Buildbot:      https://travis-ci.org/onyxfish/csvkit


### PR DESCRIPTION
Moved to https and removed the hash hack characters (#!) which are no longer needed.
