### PR TITLE
Respect --no-inference when converting xlsx

### DIFF
--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -49,19 +49,22 @@ def xlsx2csv(f, output=None, **kwargs):
         out_row = []
 
         for c in row:
-            value = c.internal_value
+            if kwargs.get('no_inference'):
+                value = c.value
+            else:
+                value = c.internal_value
 
-            if value.__class__ is datetime.datetime:
-                if value.time() != NULL_TIME:
-                    value = normalize_datetime(value)
-                else:
-                    value = value.date()
-            elif value.__class__ is float:
-                if value % 1 == 0:
-                    value = int(value)
+                if value.__class__ is datetime.datetime:
+                    if value.time() != NULL_TIME:
+                        value = normalize_datetime(value)
+                    else:
+                        value = value.date()
+                elif value.__class__ is float:
+                    if value % 1 == 0:
+                        value = int(value)
 
-            if value.__class__ in (datetime.datetime, datetime.date, datetime.time):
-                value = value.isoformat()
+                if value.__class__ in (datetime.datetime, datetime.date, datetime.time):
+                    value = value.isoformat()
 
             out_row.append(value)
 

--- a/csvkit/utilities/in2csv.py
+++ b/csvkit/utilities/in2csv.py
@@ -69,7 +69,7 @@ class In2CSV(CSVKitUtility):
             kwargs['sheet'] = self.args.sheet
 
         if self.args.no_inference:
-            kwargs['type_inference'] = False
+            kwargs['no_inference'] = True
 
         if format == 'csv' and self.args.no_header_row:
             kwargs['no_header_row'] = True


### PR DESCRIPTION
I have an xlsx file where the `c.internal_value` is not at all what it should be (`54601` instead of `E7C 3G7`, for example). Using `c.value` if the `--no-inference` flag is set solves this issue.

By the way, `'type_inference'` is used nowhere, so I normalized it to `'no_inference'` which is used elsewhere.
