### PR TITLE
Removing superflous enumerate() calls

### DIFF
--- a/csvkit/utilities/csvcut.py
+++ b/csvkit/utilities/csvcut.py
@@ -50,19 +50,19 @@ class CSVCut(CSVKitUtility):
 
         output.writerow([column_names[c] for c in column_ids])
 
-        for i, row in enumerate(rows):
-            out_row = [row[c] if c < len(row) else None for c in column_ids] 
+        for row in rows:
+            out_row = [row[c] if c < len(row) else None for c in column_ids]
 
             if self.args.delete_empty:
                 if ''.join(out_row) == '':
                     continue
-            
+
             output.writerow(out_row)
-                
+
 def launch_new_instance():
     utility = CSVCut()
     utility.main()
-    
+
 if __name__ == "__main__":
     launch_new_instance()
 

--- a/csvkit/utilities/csvgrep.py
+++ b/csvkit/utilities/csvgrep.py
@@ -43,7 +43,7 @@ class CSVGrep(CSVKitUtility):
         column_names = rows.next()
 
         column_ids = parse_column_identifiers(self.args.columns, column_names, self.args.zero_based)
-        
+
         if self.args.regex:
             pattern = re.compile(self.args.regex)
         elif self.args.matchfile:
@@ -51,7 +51,7 @@ class CSVGrep(CSVKitUtility):
             pattern = lambda x: x in lines
         else:
             pattern = self.args.pattern
-            
+
         patterns = dict((c, pattern) for c in column_ids)
 
         output = CSVKitWriter(self.output_file, **self.writer_kwargs)
@@ -59,13 +59,13 @@ class CSVGrep(CSVKitUtility):
 
         filter_reader = FilteringCSVReader(rows, header=False, patterns=patterns, inverse=self.args.inverse)
 
-        for i, row in enumerate(filter_reader):
+        for row in filter_reader:
             output.writerow(row)
 
 def launch_new_instance():
     utility = CSVGrep()
     utility.main()
-    
+
 if __name__ == "__main__":
     launch_new_instance()
 


### PR DESCRIPTION
Two files has some calls to the enumerate() function which is not needed. This can improve the speed of the `csvcut` & `csvgrep` with big files.

These changes passes the test with tox on my machine. I think there's no need for new tests cases.
