### PR TITLE
csvsql: don't try to insert data if there are no data rows (fixes #299)

### DIFF
--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -122,7 +122,7 @@ class CSVSQL(CSVKitUtility):
                     sql_table.create()
 
                 # Insert data
-                if do_insert:
+                if do_insert and csv_table.count_rows() > 0:
                     insert = sql_table.insert()
                     headers = csv_table.headers()
                     conn.execute(insert, [dict(zip(headers, row)) for row in csv_table.to_rows()])


### PR DESCRIPTION
Quick patch to check csv_table row counts before attempting an insert. For some reason a NOT NULL violation was happening with Postgres without this check. Fixes https://github.com/onyxfish/csvkit/issues/299.
