### PR TITLE
in2csv: allowed user to change output format of csv and added --decimal-delimiter flag

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -241,6 +241,27 @@ class CSVKitUtility(object):
         if 'l' not in self.override_flags and self.args.line_numbers:
             kwargs['line_numbers'] = True
 
+        if hasattr(self.args, 'out_decimal_delimiter') and self.args.out_decimal_delimiter:
+            kwargs['out_decimal_delimiter'] = self.args.out_decimal_delimiter
+
+        if hasattr(self.args, 'out_delimiter') and self.args.out_delimiter:
+            kwargs['out_delimiter'] = self.args.out_delimiter
+
+        if hasattr(self.args, 'out_encodingr') and self.args.out_encoding:
+            kwargs['out_encoding'] = self.args.out_encoding
+
+        if hasattr(self.args, 'out_quotechar') and self.args.out_quotechar:
+            kwargs['out_quotechar'] = self.args.out_quotechar
+
+        if hasattr(self.args, 'out_quoting') and self.args.out_quoting:
+            kwargs['out_qouting'] = self.args.out_quoting
+
+        if hasattr(self.args, 'out_doublequote') and self.args.out_doublequote:
+            kwargs['out_doublequote'] = True
+
+        if hasattr(self.args, 'out_escapechar') and self.args.out_escapechar:
+            kwargs['out_escapechar'] = self.args.out_escapechar
+
         return kwargs
 
     def _install_exception_handler(self):

--- a/csvkit/convert/csvitself.py
+++ b/csvkit/convert/csvitself.py
@@ -11,7 +11,7 @@ def csv2csv(f, **kwargs):
     tab = table.Table.from_csv(f, **kwargs) 
 
     o = six.StringIO()
-    output = tab.to_csv(o)
+    output = tab.to_csv(o, **kwargs)
     output = o.getvalue()
     o.close()
 

--- a/csvkit/convert/dbase.py
+++ b/csvkit/convert/dbase.py
@@ -36,7 +36,7 @@ def dbf2csv(f, **kwargs):
         tab = table.Table(columns=columns) 
 
         o = six.StringIO()
-        output = tab.to_csv(o)
+        output = tab.to_csv(o, **kwargs)
         output = o.getvalue()
         o.close()
 

--- a/csvkit/convert/fixed.py
+++ b/csvkit/convert/fixed.py
@@ -27,7 +27,7 @@ def fixed2csv(f, schema, output=None, **kwargs):
     except KeyError:
         encoding = None
 
-    writer = CSVKitWriter(output)
+    writer = CSVKitWriter(output, **kwargs)
 
     reader = FixedWidthReader(f, schema, encoding=encoding)
     writer.writerows(reader)

--- a/csvkit/convert/geojs.py
+++ b/csvkit/convert/geojs.py
@@ -46,7 +46,7 @@ def geojson2csv(f, key=None, **kwargs):
     header.append('geojson')
 
     o = six.StringIO()
-    writer = CSVKitWriter(o)
+    writer = CSVKitWriter(o, **kwargs)
 
     writer.writerow(header)
 

--- a/csvkit/convert/js.py
+++ b/csvkit/convert/js.py
@@ -57,7 +57,7 @@ def json2csv(f, key=None, **kwargs):
     fields = sorted(list(field_set))
 
     o = six.StringIO()
-    writer = CSVKitWriter(o)
+    writer = CSVKitWriter(o, *kwargs)
 
     writer.writerow(fields)
 

--- a/csvkit/convert/xls.py
+++ b/csvkit/convert/xls.py
@@ -147,7 +147,7 @@ def xls2csv(f, **kwargs):
         tab.append(column)
 
     o = six.StringIO()
-    output = tab.to_csv(o)
+    output = tab.to_csv(o, **kwargs)
     output = o.getvalue()
     o.close()
 

--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -46,7 +46,7 @@ def xlsx2csv(f, output=None, **kwargs):
     if not streaming:
         output = six.StringIO()
 
-    writer = CSVKitWriter(output)
+    writer = CSVKitWriter(output, **kwargs)
 
     book = load_workbook(f, use_iterators=True, data_only=True)
 

--- a/csvkit/py2.py
+++ b/csvkit/py2.py
@@ -18,10 +18,23 @@ class CSVKitWriter(unicsv.UnicodeCSVWriter):
     """
     A unicode-aware CSV writer with some additional features.
     """
-    def __init__(self, f, encoding='utf-8', line_numbers=False, **kwargs):
+    def __init__(self, f, line_numbers=False, **kwargs):
         self.row_count = 0
         self.line_numbers = line_numbers
-        unicsv.UnicodeCSVWriter.__init__(self, f, encoding, lineterminator='\n', **kwargs)
+        self._decimal_delimiter = kwargs.pop('out_decimal_delimiter', '.')
+        filtered_kwargs = {
+            'delimiter': kwargs.pop('out_delimiter', None),
+            'doubleqoute': kwargs.pop('out_doubleqoute', None),
+            'escapechar': kwargs.pop('out_escapechar', None),
+            'quotechar': kwargs.pop('out_quotechar', None),
+            'quoting': kwargs.pop('out_quoting', None),
+            'skipinitialspace': kwargs.pop('out_skipinitialspace', None),
+            'strict': kwargs.pop('out_strict', None),
+            'encoding': kwargs.pop('out_encoding', 'utf-8'),
+            'lineterminator': kwargs.pop('out_lineterminator', '\n')
+        }
+        filtered_kwargs = {k: v for k, v in filtered_kwargs.iteritems() if v is not None}
+        unicsv.UnicodeCSVWriter.__init__(self, f, **filtered_kwargs)
 
     def _append_line_number(self, row):
         if self.row_count == 0:
@@ -38,6 +51,9 @@ class CSVKitWriter(unicsv.UnicodeCSVWriter):
 
         # Convert embedded Mac line endings to unix style line endings so they get quoted
         row = [i.replace('\r', '\n') if isinstance(i, six.string_types) else i for i in row]
+
+        # Convert decimal delimiter of floats
+        row = [six.text_type(i).replace('.', self._decimal_delimiter) if isinstance(i, float) else i for i in row]
 
         unicsv.UnicodeCSVWriter.writerow(self, row)
 

--- a/csvkit/py3.py
+++ b/csvkit/py3.py
@@ -36,8 +36,20 @@ class CSVKitWriter(object):
     def __init__(self, f, line_numbers=False, **kwargs):
         self.row_count = 0
         self.line_numbers = line_numbers
-
-        self.writer = csv.writer(f, lineterminator='\n', **kwargs)
+        self._decimal_delimiter = kwargs.pop('out_decimal_delimiter', '.')
+        filtered_kwargs = {
+            'delimiter': kwargs.pop('out_delimiter', None),
+            'doubleqoute': kwargs.pop('out_doubleqoute', None),
+            'escapechar': kwargs.pop('out_escapechar', None),
+            'quotechar': kwargs.pop('out_quotechar', None),
+            'quoting': kwargs.pop('out_quoting', None),
+            'skipinitialspace': kwargs.pop('out_skipinitialspace', None),
+            'strict': kwargs.pop('out_strict', None),
+            'encoding': kwargs.pop('out_encoding', 'utf-8'),
+            'lineterminator': kwargs.pop('out_lineterminator', '\n')
+        }
+        filtered_kwargs = {k: v for k, v in filtered_kwargs.iteritems() if v is not None}
+        self.writer = csv.writer(f, **filtered_kwargs)
 
     def _append_line_number(self, row):
         if self.row_count == 0:
@@ -54,6 +66,9 @@ class CSVKitWriter(object):
 
         # Convert embedded Mac line endings to unix style line endings so they get quoted
         row = [i.replace('\r', '\n') if isinstance(i, six.string_types) else i for i in row]
+
+        # Convert decimal delimiter of floats
+        row = [six.text_type(i).replace('.', self._decimal_delimiter) if isinstance(i, float) else i for i in row]
 
         self.writer.writerow(row)
 

--- a/csvkit/utilities/in2csv.py
+++ b/csvkit/utilities/in2csv.py
@@ -23,6 +23,20 @@ class In2CSV(CSVKitUtility):
             help='The name of the XLSX sheet to operate on.')
         self.argparser.add_argument('--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference when parsing the input.')
+        self.argparser.add_argument('--out-decimal-delimiter', dest='out_decimal_delimiter',
+                                    help='Decimal delimiter for floats in output CSV')
+        self.argparser.add_argument('--out-delimiter', dest='out_delimiter',
+                                    help='Delimiting character of the output CSV file.')
+        self.argparser.add_argument('--out-encoding', dest='out_encoding',
+                                    help='Specify the encoding of the output CSV file.')
+        self.argparser.add_argument('-out--quotechar', dest='out_quotechar',
+                                    help='Character used to quote strings in the output CSV file.')
+        self.argparser.add_argument('--out-quoting', dest='out_quoting', type=int, choices=[0, 1, 2, 3],
+                                    help='Quoting style used in the output CSV file. 0 = Quote Minimal, 1 = Quote All, 2 = Quote Non-numeric, 3 = Quote None.')
+        self.argparser.add_argument('--out-doublequote', dest='out_doublequote', action='store_true',
+                                    help='Whether or not double quotes are doubled in the output CSV file.')
+        self.argparser.add_argument('--out-escapechar', dest='out_escapechar',
+                                    help='Character used to escape the delimiter in the output CSV if --quoting 3 ("Quote None") is specified and to escape the QUOTECHAR if --doublequote is not specified.')
 
     def main(self):
         if self.args.filetype:
@@ -65,6 +79,27 @@ class In2CSV(CSVKitUtility):
 
         if self.args.no_inference:
             kwargs['type_inference'] = False
+
+        if self.args.out_decimal_delimiter:
+            kwargs['out_decimal_delimiter'] = self.args.out_decimal_delimiter
+
+        if self.args.out_delimiter:
+            kwargs['out_delimiter'] = self.args.out_delimiter
+
+        if self.args.out_encoding:
+            kwargs['out_encoding'] = self.args.out_encoding
+
+        if self.args.out_quotechar:
+            kwargs['out_quotechar'] = self.args.out_quotechar
+
+        if self.args.out_quoting:
+            kwargs['out_qouting'] = self.args.out_quoting
+
+        if self.args.out_doublequote:
+            kwargs['out_doublequote'] = True
+
+        if self.args.out_escapechar:
+            kwargs['out_escapechar'] = self.args.out_escapechar
 
         if filetype == 'csv' and self.args.no_header_row:
             kwargs['no_header_row'] = True


### PR DESCRIPTION
When decimal separator in Windows is set to comma Excel will generate CSV with comma-separated floats and semicolon-separated fields. Sometimes external software relies on this behavior and accepts only CSVs with comma as decimal delimiter and semicolon as field delimiter for specific locale settings.

To enable csvkit users to generate CSVs for such software I added flags to change settings of output csv and also added custom flag to replace '.' in floats.
