### PR TITLE
Update csvjoin.rst

### DIFF
--- a/docs/scripts/csvjoin.rst
+++ b/docs/scripts/csvjoin.rst
@@ -8,7 +8,7 @@ Description
 Merges two or more CSV tables together using a method analogous to SQL JOIN operation. By default it performs an inner join, but full outer, left outer, and right outer are also available via flags. Key columns are specified with the -c flag (either a single column which exists in all tables, or a comma-seperated list of columns with one corresponding to each). If the columns flag is not provided then the tables will be merged "sequentially", that is they will be merged in row order with no filtering::
 
     usage: csvjoin [-h] [-d DELIMITER] [-t] [-q QUOTECHAR] [-u {0,1,2,3}] [-b]
-                   [-p` ESCAPECHAR] [-e ENCODING] [-j JOIN] [--outer] [--left]
+                   [-p` ESCAPECHAR] [-e ENCODING] [--outer] [--left]
                    [--right]
                    FILES [FILES ...]
 


### PR DESCRIPTION
removed  [-j JOIN] option from usage, not sure it is valid - this is my usage output:

```
$ pip show csvkit

---
Name: csvkit
Version: 0.9.0
Location: /usr/local/lib/python2.7/site-packages
Requires: xlrd, sqlalchemy, openpyxl, six, python-dateutil, dbf
$ csvjoin
usage: csvjoin [-h] [-d DELIMITER] [-t] [-q QUOTECHAR] [-u {0,1,2,3}] [-b]
               [-p ESCAPECHAR] [-z MAXFIELDSIZE] [-e ENCODING] [-S] [-v] [-l]
               [--zero] [-c COLUMNS] [--outer] [--left] [--right]
               [FILE [FILE ...]]
csvjoin: error: You must specify at least two files to join.
```
