### PR TITLE
Fix working with ERROR cells in xls

### DIFF
--- a/csvkit/convert/xls.py
+++ b/csvkit/convert/xls.py
@@ -101,7 +101,8 @@ NORMALIZERS = {
     xlrd.biffh.XL_CELL_TEXT: normalize_text,
     xlrd.biffh.XL_CELL_NUMBER: normalize_numbers,
     xlrd.biffh.XL_CELL_DATE: normalize_dates,
-    xlrd.biffh.XL_CELL_BOOLEAN: normalize_booleans
+    xlrd.biffh.XL_CELL_BOOLEAN: normalize_booleans,
+    xlrd.biffh.XL_CELL_ERROR: normalize_empty
 }
 
 def determine_column_type(types):
@@ -139,6 +140,9 @@ def xls2csv(f, **kwargs):
 
         values = sheet.col_values(i)[1:]
         types = sheet.col_types(i)[1:]
+
+        values = [value if type_ != xlrd.biffh.XL_CELL_ERROR else None
+                  for value, type_ in zip(values, types)]
 
         column_type = determine_column_type(types)
         t, normal_values = NORMALIZERS[column_type](values, datemode=book.datemode)

--- a/csvkit/table.py
+++ b/csvkit/table.py
@@ -39,7 +39,7 @@ class Column(list):
         
         list.__init__(self, data)
         self.order = order
-        self.name = name or '_unnamed' # empty column names don't make sense 
+        self.name = str(name) or '_unnamed' # empty column names don't make sense 
         self.type = t
         
     def __str__(self):


### PR DESCRIPTION
Cells with ERROR value in xls files are moved to CSV as error code numbers.
The change makes all ERROR cells to be empty.

Also there is a fix for non-string column names.