### PR TITLE
Simplify (and speed up) the sorting call to agate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Backwards-incompatible changes:
 
 * The --doublequote long flag is gone, and the -b short flag is now an alias for --no-doublequote.
 * When using the --columns or --not-columns options, you must not have spaces around the comma-separated values, unless the column names contain spaces.
+* When sorting, null values are now greater than other values instead of less than.
 * CSVKitReader, CSVKitWriter, CSVKitDictReader, and CSVKitDictWriter have been removed. Use agate.csv.reader, agate.csv.writer, agate.csv.DictReader and agate.csv.DictWriter.
 * Drop Python 2.6 support.
 

--- a/csvkit/utilities/csvsort.py
+++ b/csvkit/utilities/csvsort.py
@@ -27,7 +27,7 @@ class CSVSort(CSVKitUtility):
 
         table = agate.Table.from_csv(self.input_file, sniff_limit=self.args.sniff_limit, header=not self.args.no_header_row, column_types=self.get_column_types(), **self.reader_kwargs)
         column_ids = parse_column_identifiers(self.args.columns, table.column_names, column_offset=self.get_column_offset())
-        table = table.order_by(lambda row: [(row[column_id] is not None, row[column_id]) for column_id in column_ids], reverse=self.args.reverse)
+        table = table.order_by(column_ids, reverse=self.args.reverse)
         table.to_csv(self.output_file, **self.writer_kwargs)
 
 

--- a/tests/test_utilities/test_csvsort.py
+++ b/tests/test_utilities/test_csvsort.py
@@ -29,7 +29,7 @@ class TestCSVSort(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
 
     def test_sort_date(self):
         reader = self.get_output_as_reader(['-c', '2', 'examples/testxls_converted.csv'])
-        test_order = [u'text', u'This row has blanks', u'Unicode! Σ', u'Chicago Tribune', u'Chicago Sun-Times', u'Chicago Reader']
+        test_order = [u'text', u'Chicago Tribune', u'Chicago Sun-Times', u'Chicago Reader', u'This row has blanks', u'Unicode! Σ']
         new_order = [six.text_type(r[0]) for r in reader]
         self.assertEqual(test_order, new_order)
 
@@ -45,8 +45,8 @@ class TestCSVSort(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
         new_order = [six.text_type(r[0]) for r in reader]
         self.assertEqual(test_order, new_order)
 
-    def test_sort_ints_and_nulls(self):
+    def test_sort_t_and_nulls(self):
         reader = self.get_output_as_reader(['-c', '2', 'examples/sort_ints_nulls.csv'])
-        test_order = ['b', '', '1', '2']
+        test_order = ['b', '1', '2', '']
         new_order = [six.text_type(r[1]) for r in reader]
         self.assertEqual(test_order, new_order)


### PR DESCRIPTION
Instead of using a `lambda` in the `order_by` in csvkit, we could now delegate this to agate. However, csvkit's rule for `None` was that it is less than everything, but in agate, `None` is greater than everything. Would this be a breaking change, or can we change the rule?

/cc @onyxfish 

Also, note that this PR may fail until agate is released with https://github.com/wireservice/agate/pull/607 merged.