### PR TITLE
Implement case-insensitive key comparison for csvjoin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/_build
 .coverage
 .tox
 cover
+env

--- a/csvkit/utilities/csvjoin.py
+++ b/csvkit/utilities/csvjoin.py
@@ -22,6 +22,8 @@ class CSVJoin(CSVKitUtility):
                                     help='Perform a left outer join, rather than the default inner join. If more than two files are provided this will be executed as a sequence of left outer joins, starting at the left.')
         self.argparser.add_argument('--right', dest='right_join', action='store_true',
                                     help='Perform a right outer join, rather than the default inner join. If more than two files are provided this will be executed as a sequence of right outer joins, starting at the right.')
+        self.argparser.add_argument('--ignorecase', dest='ignore_case', action='store_true',
+                                    help='Whether to ignore string case when comparing keys.')
 
     def main(self):
         self.input_files = []
@@ -62,10 +64,11 @@ class CSVJoin(CSVKitUtility):
 
         jointab = tables[0]
 
+        ignore_case = self.args.ignore_case
         if self.args.left_join:
             # Left outer join
             for i, t in enumerate(tables[1:]):
-                jointab = join.left_outer_join(jointab, join_column_ids[0], t, join_column_ids[i + 1], header=header)
+                jointab = join.left_outer_join(jointab, join_column_ids[0], t, join_column_ids[i + 1], header=header, ignore_case=ignore_case)
         elif self.args.right_join:
             # Right outer join
             jointab = tables[-1]
@@ -74,15 +77,15 @@ class CSVJoin(CSVKitUtility):
             remaining_tables.reverse()
 
             for i, t in enumerate(remaining_tables):
-                jointab = join.right_outer_join(t, join_column_ids[-(i + 2)], jointab, join_column_ids[-1], header=header)
+                jointab = join.right_outer_join(t, join_column_ids[-(i + 2)], jointab, join_column_ids[-1], header=header, ignore_case=ignore_case)
         elif self.args.outer_join:
             # Full outer join
             for i, t in enumerate(tables[1:]):
-                jointab = join.full_outer_join(jointab, join_column_ids[0], t, join_column_ids[i + 1], header=header)
+                jointab = join.full_outer_join(jointab, join_column_ids[0], t, join_column_ids[i + 1], header=header, ignore_case=ignore_case)
         elif self.args.columns:
             # Inner join
             for i, t in enumerate(tables[1:]):
-                jointab = join.inner_join(jointab, join_column_ids[0], t, join_column_ids[i + 1], header=header)
+                jointab = join.inner_join(jointab, join_column_ids[0], t, join_column_ids[i + 1], header=header, ignore_case=ignore_case)
         else:
             # Sequential join
             for t in tables[1:]:

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -25,15 +25,22 @@ class TestJoin(unittest.TestCase):
             [u'1', u'second', u'0'],
             [u'2', u'only', u'0', u'0']]  # Note extra value in this column
 
-    def test_get_ordered_keys(self):
-        self.assertEqual(join._get_ordered_keys(self.tab1[1:], 0), [u'1', u'2', u'3', u'1'])
-        self.assertEqual(join._get_ordered_keys(self.tab2[1:], 0), [u'1', u'4', u'1', u'2'])
+    def test_get_keys(self):
+        self.assertEqual(join._get_keys(self.tab1[1:], 0).keys(), set([u'1', u'2', u'3', u'1']))
+        self.assertEqual(join._get_keys(self.tab2[1:], 0).keys(), set([u'1', u'4', u'1', u'2']))
 
     def test_get_mapped_keys(self):
         self.assertEqual(join._get_mapped_keys(self.tab1[1:], 0), {
             u'1': [[u'1', u'Chicago Reader', u'first'], [u'1', u'Chicago Reader', u'second']],
             u'2': [[u'2', u'Chicago Sun-Times', u'only']],
             u'3': [[u'3', u'Chicago Tribune', u'only']]})
+
+    def test_get_mapped_keys_ignore_case(self):
+        mapped_keys = join._get_mapped_keys(self.tab1[1:], 1, case_insensitive=True)
+        assert u'Chicago Reader' in mapped_keys
+        assert u'chicago reader' in mapped_keys
+        assert u'CHICAGO SUN-TIMES' in mapped_keys
+        assert u'1' not in mapped_keys
 
     def test_sequential_join(self):
         self.assertEqual(join.sequential_join(self.tab1, self.tab2), [
@@ -82,3 +89,28 @@ class TestJoin(unittest.TestCase):
             [u'1', u'Chicago Reader', u'second', u'1', u'first', u'0'],
             [u'1', u'Chicago Reader', u'second', u'1', u'second', u'0'],
             [u'', u'', u'', u'4', u'only', u'0']])
+
+    def test_right_outer_join_ignore_case(self):
+        # Right outer join exercises all the case dependencies
+        tab1 = [
+            ['id', 'name', 'i_work_here'],
+            [u'a', u'Chicago Reader', u'first'],
+            [u'b', u'Chicago Sun-Times', u'only'],
+            [u'c', u'Chicago Tribune', u'only'],
+            [u'a', u'Chicago Reader', u'second']]
+
+        tab2 = [
+            ['id', 'age', 'i_work_here'],
+            [u'A', u'first', u'0'],
+            [u'D', u'only', u'0'],
+            [u'A', u'second', u'0'],
+            [u'B', u'only', u'0', u'0']]  # Note extra value in this column
+
+        self.assertEqual(join.right_outer_join(tab1, 0, tab2, 0, ignore_case=True), [
+                ['id', 'name', 'i_work_here', 'id', 'age', 'i_work_here'],
+                [u'a', u'Chicago Reader', u'first', u'A', u'first', u'0'],
+                [u'a', u'Chicago Reader', u'first', u'A', u'second', u'0'],
+                [u'b', u'Chicago Sun-Times', u'only', u'B', u'only', u'0', u'0'],
+                [u'a', u'Chicago Reader', u'second', u'A', u'first', u'0'],
+                [u'a', u'Chicago Reader', u'second', u'A', u'second', u'0'],
+                [u'', u'', u'', u'D', u'only', u'0']])


### PR DESCRIPTION
This is much nicer than lowercasing files to do the join then trying to restore case that's important later on.

Thanks for the great tools!