### PR TITLE
csvlook: Fix "underlying stream is not seekable" when piping input

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -65,6 +65,7 @@ class CSVKitUtility(object):
     description = ''
     epilog = ''
     override_flags = ''
+    buffers_input = False
 
     def __init__(self, args=None, output_file=None):
         """
@@ -187,7 +188,10 @@ class CSVKitUtility(object):
             kwargs = {'encoding': self.args.encoding}
 
         if not path or path == '-':
-            f = sys.stdin
+            if self.buffers_input:
+                f = six.StringIO(sys.stdin.read())
+            else:
+                f = sys.stdin
         else:
             (_, extension) = os.path.splitext(path)
 

--- a/csvkit/utilities/csvjson.py
+++ b/csvkit/utilities/csvjson.py
@@ -19,6 +19,7 @@ from csvkit.cli import CSVKitUtility, match_column_identifier
 class CSVJSON(CSVKitUtility):
     description = 'Convert a CSV file into JSON (or GeoJSON).'
     override_flags = ['H']
+    buffers_input = True
 
     def add_arguments(self):
         self.argparser.add_argument('-i', '--indent', dest='indent', type=int, default=None,

--- a/csvkit/utilities/csvlook.py
+++ b/csvkit/utilities/csvlook.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-
 import agate
-import six
 
 from csvkit.cli import CSVKitUtility
 
 
 class CSVLook(CSVKitUtility):
     description = 'Render a CSV file in the console as a fixed-width table.'
+    buffers_input = True
 
     def add_arguments(self):
         self.argparser.add_argument('--max-rows', dest='max_rows', type=int,
@@ -24,11 +22,6 @@ class CSVLook(CSVKitUtility):
                                     help='Disable type inference when parsing the input.')
 
     def main(self):
-        # Otherwise, fails with "io.UnsupportedOperation: underlying stream is not seekable".
-        if self.input_file == sys.stdin:
-            # We can't sort without reading the entire input.
-            self.input_file = six.StringIO(sys.stdin.read())
-
         table = agate.Table.from_csv(self.input_file, sniff_limit=self.args.sniff_limit, header=not self.args.no_header_row, column_types=self.get_column_types(), line_numbers=self.args.line_numbers, **self.reader_kwargs)
         table.print_table(output=self.output_file, max_rows=self.args.max_rows, max_columns=self.args.max_columns, max_column_width=self.args.max_column_width)
 

--- a/csvkit/utilities/csvlook.py
+++ b/csvkit/utilities/csvlook.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
+import sys
+
 import agate
+import six
 
 from csvkit.cli import CSVKitUtility
 
@@ -21,6 +24,11 @@ class CSVLook(CSVKitUtility):
                                     help='Disable type inference when parsing the input.')
 
     def main(self):
+        # Otherwise, fails with "io.UnsupportedOperation: underlying stream is not seekable".
+        if self.input_file == sys.stdin:
+            # We can't sort without reading the entire input.
+            self.input_file = six.StringIO(sys.stdin.read())
+
         table = agate.Table.from_csv(self.input_file, sniff_limit=self.args.sniff_limit, header=not self.args.no_header_row, column_types=self.get_column_types(), line_numbers=self.args.line_numbers, **self.reader_kwargs)
         table.print_table(output=self.output_file, max_rows=self.args.max_rows, max_columns=self.args.max_columns, max_column_width=self.args.max_column_width)
 

--- a/csvkit/utilities/csvsort.py
+++ b/csvkit/utilities/csvsort.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-
 import agate
-import six
 
 from csvkit.cli import CSVKitUtility, parse_column_identifiers
 
 
 class CSVSort(CSVKitUtility):
     description = 'Sort CSV files. Like the Unix "sort" command, but for tabular data.'
+    buffers_input = True
 
     def add_arguments(self):
         self.argparser.add_argument('-n', '--names', dest='names_only', action='store_true',
@@ -27,11 +25,6 @@ class CSVSort(CSVKitUtility):
         if self.args.names_only:
             self.print_column_names()
             return
-
-        # Otherwise, fails with "io.UnsupportedOperation: underlying stream is not seekable".
-        if self.input_file == sys.stdin:
-            # We can't sort without reading the entire input.
-            self.input_file = six.StringIO(sys.stdin.read())
 
         table = agate.Table.from_csv(self.input_file, sniff_limit=self.args.sniff_limit, header=not self.args.no_header_row, column_types=self.get_column_types(), **self.reader_kwargs)
         column_ids = parse_column_identifiers(self.args.columns, table.column_names, column_offset=self.get_column_offset())

--- a/csvkit/utilities/in2csv.py
+++ b/csvkit/utilities/in2csv.py
@@ -53,6 +53,8 @@ class In2CSV(CSVKitUtility):
             if not filetype:
                 self.argparser.error('Unable to automatically determine the format of the input file. Try specifying a format with --format.')
 
+        self.buffers_input = filetype == 'csv' or not self.args.no_inference
+
         # Set the input file.
         if filetype in ('xls', 'xlsx'):
             self.input_file = open(self.args.input_path, 'rb')


### PR DESCRIPTION
Closes #623 