### PR TITLE
Fix output encoding error in Python 2

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -68,7 +68,10 @@ class CSVKitUtility(object):
         self._init_common_parser()
         self.add_arguments()
         self.args = self.argparser.parse_args(args)
-        self.output_file_handle = output_file
+        if output_file is None:
+            self.output_file = sys.stdout
+        else:
+            self.output_file = output_file
 
         self.reader_kwargs = self._extract_csv_reader_kwargs()
         self.writer_kwargs = self._extract_csv_writer_kwargs()
@@ -105,14 +108,6 @@ class CSVKitUtility(object):
         """
         if 'f' not in self.override_flags:
             self.input_file = self._open_input_file(self.args.input_path)
-
-        if self.output_file_handle is None:
-            if six.PY2:
-                self.output_file = codecs.getwriter('utf-8')(sys.stdout)
-            else:
-                self.output_file = sys.stdout
-        else:
-            self.output_file = self.output_file_handle
 
         try:
             self.main()

--- a/csvkit/utilities/csvjson.py
+++ b/csvkit/utilities/csvjson.py
@@ -40,6 +40,7 @@ class CSVJSON(CSVKitUtility):
                                     help='Disable type inference when parsing CSV input.')
 
     def main(self):
+        # We need to do this dance here, because we aren't writing through agate.
         if six.PY2:
             stream = codecs.getwriter('utf-8')(self.output_file)
         else:
@@ -182,7 +183,7 @@ class CSVJSON(CSVKitUtility):
                 self.output_file,
                 key=self.args.key,
                 newline=self.args.streamOutput,
-                **json_kwargs
+                indent=self.args.indent
             )
 
 


### PR DESCRIPTION
Closes #732 

The issue was that we would double encode files.