### PR TITLE
Properly accept % in queries

### DIFF
--- a/csvkit/utilities/sql2csv.py
+++ b/csvkit/utilities/sql2csv.py
@@ -54,7 +54,7 @@ class SQL2CSV(CSVKitUtility):
         # Must escape '%'.
         # @see https://github.com/wireservice/csvkit/issues/440
         # @see https://bitbucket.org/zzzeek/sqlalchemy/commits/5bc1f17cb53248e7cea609693a3b2a9bb702545b
-        rows = connection.execute(query.replace('%', '%%'))
+        rows = connection.execute_options(no_parameters=True).execute(query)
         output = agate.csv.writer(self.output_file, **self.writer_kwargs)
 
         if rows.returns_rows:


### PR DESCRIPTION
I noticed a bug when trying to use the DATE_FORMAT() function with a MySQL database using mysqlconnector dialect. This function requires % characters as format specifiers, see [MySQL documentation](http://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format). Previously using the mysqldb dialect I had no problems.

Compare the output from the following two commands:
```
sql2csv --db "mysql+mysqldb://...?charset=utf8" --query "select DATE_FORMAT(NOW(), '%c'), '%' AS '%'"
sql2csv --db "mysql+mysqlconnector://...?charset=utf8" --query "select DATE_FORMAT(NOW(), '%c'), '%' AS '%'"
```