### PR TITLE
Add --create-if-not-exists flag to csvsql

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,3 +73,4 @@ The following individuals have contributed code to csvkit:
 * Éric Araujo
 * Sam Stuck
 * Edward Betts
+* Jake Zimmerman

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Improvements:
 * :doc:`/scripts/csvsql` adds a :code:`--overwrite` flag to drop any existing table with the same name before creating.
 * :doc:`/scripts/csvsql` accepts a file name for the :code:`--query` option.
 * :doc:`/scripts/csvsql` supports :code:`--linenumbers` (no-op).
+* :doc:`/scripts/csvsql` adds a :code:`--create-if-not-exists` flag to not abort if the table already exists
 * :doc:`/scripts/csvstat` adds a :code:`--freq-count` option to set the maximum number of frequent values to display.
 * :doc:`/scripts/csvstat` supports :code:`--linenumbers` (no-op).
 * :doc:`/scripts/in2csv` adds a :code:`--names` flag to print Excel sheet names.

--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -38,6 +38,8 @@ class CSVSQL(CSVKitUtility):
                                     help='Generate a schema without length limits or null checks. Useful when sampling big tables.')
         self.argparser.add_argument('--no-create', dest='no_create', action='store_true',
                                     help='Skip creating a table. Only valid when --insert is specified.')
+        self.argparser.add_argument('--create-if-not-exists', dest='create_if_not_exists', action='store_true',
+                                    help='Create table if it does not exist, otherwise keep going. Only valid when --insert is specified.')
         self.argparser.add_argument('--overwrite', dest='overwrite', action='store_true',
                                     help='Drop the table before creating.')
         self.argparser.add_argument('--db-schema', dest='db_schema',
@@ -67,7 +69,13 @@ class CSVSQL(CSVKitUtility):
             self.argparser.error('The --insert option is only valid when either --db or --query is specified.')
 
         if self.args.no_create and not self.args.insert:
-            self.argparser.error('The --no-create option is only valid --insert is also specified.')
+            self.argparser.error('The --no-create option is only valid if --insert is also specified.')
+
+        if self.args.create_if_not_exists and not self.args.insert:
+            self.argparser.error('The --create-if-not-exists option is only valid if --insert is also specified.')
+
+        if self.args.no_create and self.args.create_if_not_exists:
+            self.argparser.error('The --no-create and --create-if-not-exists options are mutually exclusive.')
 
         # Lazy open files
         for path in self.args.input_paths:
@@ -132,6 +140,7 @@ class CSVSQL(CSVKitUtility):
                         table_name,
                         overwrite=self.args.overwrite,
                         create=not self.args.no_create,
+                        create_if_not_exists=self.args.create_if_not_exists,
                         insert=self.args.insert and len(table.rows) > 0,
                         prefixes=self.args.prefix,
                         db_schema=self.args.db_schema,

--- a/examples/foo1.csv
+++ b/examples/foo1.csv
@@ -1,0 +1,3 @@
+id,name,age
+1,Jake,22
+2,Howard,21

--- a/examples/foo2.csv
+++ b/examples/foo2.csv
@@ -1,0 +1,3 @@
+id,name,age
+3,Liz,20
+4,Tim,21

--- a/tests/test_utilities/test_csvsql.py
+++ b/tests/test_utilities/test_csvsql.py
@@ -6,6 +6,7 @@ import sys
 
 import six
 from sqlalchemy import Index, MetaData, Table, create_engine
+from sqlalchemy.exc import OperationalError
 
 try:
     from mock import patch
@@ -161,6 +162,13 @@ class TestCSVSQL(CSVKitTestCase, EmptyFileTests):
     def test_create_if_not_exists(self):
         self.get_output(['--insert', '--create-if-not-exists', '--tables', 'foo', '--db', 'sqlite:///' + self.db_file, 'examples/foo1.csv'])
         self.get_output(['--insert', '--create-if-not-exists', '--tables', 'foo', '--db', 'sqlite:///' + self.db_file, 'examples/foo2.csv'])
+
+    def test_create_if_not_exists_error(self):
+        self.get_output(['--insert', '--tables', 'foobad', '--db', 'sqlite:///' + self.db_file, 'examples/foo1.csv'])
+        try:
+            self.get_output(['--insert', '--tables', 'foobad', '--db', 'sqlite:///' + self.db_file, 'examples/foo2.csv'])
+        except OperationalError:
+            pass
 
     def test_query(self):
         input_file = six.StringIO("a,b,c\n1,2,3\n")

--- a/tests/test_utilities/test_csvsql.py
+++ b/tests/test_utilities/test_csvsql.py
@@ -158,6 +158,10 @@ class TestCSVSQL(CSVKitTestCase, EmptyFileTests):
 
         self.get_output(['--prefix', 'OR IGNORE', '--no-create', '--insert', '--db', 'sqlite:///' + self.db_file, 'examples/dummy.csv'])
 
+    def test_create_if_not_exists(self):
+        self.get_output(['--insert', '--create-if-not-exists', '--tables', 'foo', '--db', 'sqlite:///' + self.db_file, 'examples/foo1.csv'])
+        self.get_output(['--insert', '--create-if-not-exists', '--tables', 'foo', '--db', 'sqlite:///' + self.db_file, 'examples/foo2.csv'])
+
     def test_query(self):
         input_file = six.StringIO("a,b,c\n1,2,3\n")
 


### PR DESCRIPTION
/cc @jpmckinney

Surfaces the new `create_if_not_exists` keyword arg in `agate-sql` (see
wireservice/agate-sql#25) as a command line flag.

For context, see #813.

By the way, is there some special development setup to develop csvkit and
agate-sql in tandem? (I was just developing agate-sql in the virtualenv XD)