### PR TITLE
Close matchfile after reading it (#838)

### DIFF
--- a/csvkit/utilities/csvgrep.py
+++ b/csvkit/utilities/csvgrep.py
@@ -50,6 +50,8 @@ class CSVGrep(CSVKitUtility):
             pattern = re.compile(self.args.regex)
         elif self.args.matchfile:
             lines = set(line.rstrip() for line in self.args.matchfile)
+            self.args.matchfile.close()
+            self.args.matchfile = None
 
             def pattern(x):
                 return x in lines


### PR DESCRIPTION
This prevents an intermittent error when csvgrep exits:

    sys:1: ResourceWarning: unclosed file \
    <_io.TextIOWrapper name='foo.txt' mode='r' encoding='UTF-8'>