### PR TITLE
csvgrep accepts utf-8 arguments to the --match and --regex options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 
 Fixes:
 
+* :doc:`/scripts/csvgrep` accepts utf-8 arguments to the :code:`--match` and :code:`--regex` options in Python 2.
 * :doc:`/scripts/in2csv` respects :code:`--no-header-row` when :code:`--no-inference` is set.
 
 1.0.2 - April 28, 2017

--- a/csvkit/utilities/csvgrep.py
+++ b/csvkit/utilities/csvgrep.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
 import re
+import sys
 from argparse import FileType
 
 import agate
+import six
 
 from csvkit.cli import CSVKitUtility
 from csvkit.grep import FilteringCSVReader
@@ -14,13 +16,20 @@ class CSVGrep(CSVKitUtility):
     override_flags = ['L', 'blanks', 'date-format', 'datetime-format']
 
     def add_arguments(self):
+        # I feel that there ought to be a better way to do this across Python 2 and 3.
+        def option_parser(bytestring):
+            if six.PY2:
+                return bytestring.decode(sys.getfilesystemencoding())
+            else:
+                return bytestring
+
         self.argparser.add_argument('-n', '--names', dest='names_only', action='store_true',
                                     help='Display column names and indices from the input CSV and exit.')
         self.argparser.add_argument('-c', '--columns', dest='columns',
                                     help='A comma separated list of column indices or names to be searched.')
-        self.argparser.add_argument('-m', '--match', dest="pattern", action='store',
+        self.argparser.add_argument('-m', '--match', dest="pattern", action='store', type=option_parser,
                                     help='The string to search for.')
-        self.argparser.add_argument('-r', '--regex', dest='regex', action='store',
+        self.argparser.add_argument('-r', '--regex', dest='regex', action='store', type=option_parser,
                                     help='If specified, must be followed by a regular expression which will be tested against the specified columns.')
         self.argparser.add_argument('-f', '--file', dest='matchfile', type=FileType('r'), action='store',
                                     help='If specified, must be the path to a file. For each tested row, if any line in the file (stripped of line separators) is an exact match for the cell value, the row will pass.')

--- a/tests/test_utilities/test_csvgrep.py
+++ b/tests/test_utilities/test_csvgrep.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import sys
 
@@ -32,6 +33,12 @@ class TestCSVGrep(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
             ['1', '2', '3'],
         ])
 
+    def test_match_utf8(self):
+        self.assertRows(['-c', '3', '-m', 'ʤ', 'examples/test_utf8.csv'], [
+            ['foo', 'bar', 'baz'],
+            ['4' , '5', u'ʤ'],
+        ])
+
     def test_no_match(self):
         self.assertRows(['-c', '1', '-m', 'NO MATCH', 'examples/dummy.csv'], [
             ['a', 'b', 'c'],
@@ -47,6 +54,12 @@ class TestCSVGrep(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
         self.assertRows(['-c', '3', '-r', '^(3|9)$', 'examples/dummy.csv'], [
             ['a', 'b', 'c'],
             ['1', '2', '3'],
+        ])
+
+    def test_re_match_utf8(self):
+        self.assertRows(['-c', '3', '-r', 'ʤ', 'examples/test_utf8.csv'], [
+            ['foo', 'bar', 'baz'],
+            ['4' , '5', u'ʤ'],
         ])
 
     def test_string_match(self):


### PR DESCRIPTION
For Python 2, fixes #854