### PR TITLE
Allow using any_match with csvgrep

### DIFF
--- a/csvkit/utilities/csvgrep.py
+++ b/csvkit/utilities/csvgrep.py
@@ -35,7 +35,8 @@ class CSVGrep(CSVKitUtility):
                                     help='If specified, must be the path to a file. For each tested row, if any line in the file (stripped of line separators) is an exact match for the cell value, the row will pass.')
         self.argparser.add_argument('-i', '--invert-match', dest='inverse', action='store_true',
                                     help='If specified, select non-matching instead of matching rows.')
-
+        self.argparser.add_argument('-a', '--any-match', dest='any_match', action='store_true',
+                                    help='If specified, select rows where any column matches instead of all columns.')
     def main(self):
         if self.args.names_only:
             self.print_column_names()
@@ -67,7 +68,7 @@ class CSVGrep(CSVKitUtility):
             pattern = self.args.pattern
 
         patterns = dict((column_id, pattern) for column_id in column_ids)
-        filter_reader = FilteringCSVReader(rows, header=False, patterns=patterns, inverse=self.args.inverse)
+        filter_reader = FilteringCSVReader(rows, header=False, patterns=patterns, inverse=self.args.inverse, any_match=self.args.any_match)
 
         output = agate.csv.writer(self.output_file, **writer_kwargs)
         output.writerow(column_names)

--- a/docs/scripts/csvgrep.rst
+++ b/docs/scripts/csvgrep.rst
@@ -38,6 +38,8 @@ Filter tabular data to only those rows where certain columns contain a given val
                             row will pass.
       -i, --invert-match    If specified, select non-matching instead of matching
                             rows.
+      -a  --any-match       If specified, select rows where any column matches
+                            instead of all columns.
 
 See also: :doc:`../common_arguments`.
 
@@ -53,8 +55,7 @@ Search for the row relating to Illinois::
 Search for rows relating to states with names beginning with the letter "I"::
 
     csvgrep -c 1 -r "^I" examples/realdata/FY09_EDU_Recipients_by_State.csv
-    
+
 Search for rows that do not contain an empty state cell::
 
     csvgrep -c 1 -r "^$" -i examples/realdata/FY09_EDU_Recipients_by_State.csv
-

--- a/tests/test_utilities/test_csvgrep.py
+++ b/tests/test_utilities/test_csvgrep.py
@@ -33,6 +33,12 @@ class TestCSVGrep(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
             ['1', '2', '3'],
         ])
 
+    def test_any_match(self):
+        self.assertRows(['-c', '1,2,3', '-a', '-m', '1', 'examples/dummy.csv'], [
+            ['a', 'b', 'c'],
+            ['1', '2', '3'],
+        ])
+
     def test_match_utf8(self):
         self.assertRows(['-c', '3', '-m', 'ʤ', 'examples/test_utf8.csv'], [
             ['foo', 'bar', 'baz'],


### PR DESCRIPTION
This simply adds a `-a / --any-match` flag to csvgrep to allow people to use the `any_match` functionality of the FilteringCSVReader.

I noticed that the `any_match` arg has tests but isn't used anywhere, so I'm not sure whether or not it was intentionally left out of csvgrep, but I needed it for something I was working on so I figured I'd add a test and make a quick PR.

Thanks for building such a great set of tools, I use csvkit constantly!