### PR TITLE
Add missing files for docs to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include README.rst
 recursive-include docs *
 recursive-include examples *
 recursive-include tests *.py
+include AUTHORS.rst
+include CHANGELOG.rst


### PR DESCRIPTION
Otherwise, building the documentation from the PyPI tarball yields the following:
```
/<<PKGBUILDDIR>>/docs/changelog.rst:5: WARNING: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: '../CHANGELOG.rst'.
/<<PKGBUILDDIR>>/docs/index.rst:90: WARNING: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: '../AUTHORS.rst'.
```