### PR TITLE
Adds chunk_size to csvsql options

### DIFF
--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -53,6 +53,8 @@ class CSVSQL(CSVKitUtility):
                                     help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing entirely.')
         self.argparser.add_argument('-I', '--no-inference', dest='no_inference', action='store_true',
                                     help='Disable type inference when parsing the input.')
+        self.argparser.add_argument('--chunk-size', dest='chunk_size', type=int,
+                                    help='Optional chunk size. Only valid when --insert is specified.')
 
     def main(self):
         if sys.stdin.isatty() and not self.args.input_paths:
@@ -85,9 +87,11 @@ class CSVSQL(CSVKitUtility):
         if self.args.overwrite and not self.args.insert:
             self.argparser.error('The --overwrite option is only valid if --insert is also specified.')
         if self.args.before_insert and not self.args.insert:
-            self.argparser.error('The --before_insert option is only valid if --insert is also specified.')
+            self.argparser.error('The --before-insert option is only valid if --insert is also specified.')
         if self.args.after_insert and not self.args.insert:
-            self.argparser.error('The --after_insert option is only valid if --insert is also specified.')
+            self.argparser.error('The --after-insert option is only valid if --insert is also specified.')
+        if self.args.chunk_size and not self.args.insert:
+            self.argparser.error('The --chunk-size option is only valid if --insert is also specified.')
 
         if self.args.no_create and self.args.create_if_not_exists:
             self.argparser.error('The --no-create and --create-if-not-exists options are mutually exclusive.')
@@ -164,7 +168,8 @@ class CSVSQL(CSVKitUtility):
                         prefixes=self.args.prefix,
                         db_schema=self.args.db_schema,
                         constraints=not self.args.no_constraints,
-                        unique_constraint=self.unique_constraint
+                        unique_constraint=self.unique_constraint,
+                        chunk_size=self.args.chunk_size
                     )
 
                     if self.args.after_insert:

--- a/docs/scripts/csvsql.rst
+++ b/docs/scripts/csvsql.rst
@@ -17,7 +17,7 @@ Generate SQL statements for a CSV file or execute those statements directly on a
                   [--prefix PREFIX] [--tables TABLE_NAMES] [--no-constraints]
                   [--unique-constraint UNIQUE_CONSTRAINT] [--no-create]
                   [--create-if-not-exists] [--overwrite] [--db-schema DB_SCHEMA]
-                  [-y SNIFF_LIMIT] [-I]
+                  [-y SNIFF_LIMIT] [-I] [--chunk-size NUM]
                   [FILE [FILE ...]]
 
     Generate SQL statements for one or more CSV files, or execute those statements
@@ -65,7 +65,9 @@ Generate SQL statements for a CSV file or execute those statements directly on a
                             Limit CSV dialect sniffing to the specified number of
                             bytes. Specify "0" to disable sniffing entirely.
       -I, --no-inference    Disable type inference when parsing the input.
-
+      --chunk-size NUM
+                            Chunk size for batch insert into the table.
+                            Only valid when --insert is specified.
 
 See also: :doc:`../common_arguments`.
 


### PR DESCRIPTION
The option is already [available](https://github.com/wireservice/agate-sql/blob/f46bffb9125c7d5b9d0b41628a111f0ee1d8dd16/agatesql/table.py#L220). This is just exposing it in csvsql. Also, we are just passing the value along to agate-sql. So I didn't think there is a need for new test.

Let me know what you think.