### PR TITLE
fix openpyxl to 2.2.0 instead of a beta version

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -5,7 +5,7 @@ python-dateutil==2.2
 SQLAlchemy>=0.9.3
 sphinx>=1.0.7
 coverage>=3.5.1b1
-openpyxl==2.2.0-b1
+openpyxl==2.2.0
 tox>=1.3
 dbf==0.95.004
 unittest2==0.5.1

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -4,7 +4,7 @@ python-dateutil>=2.2
 SQLAlchemy>=0.9.3
 sphinx>=1.0.7
 coverage>=3.5.1b1
-openpyxl==2.2.0-b1
+openpyxl==2.2.0
 tox>=1.3
 six>=1.6.1
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 install_requires = [
     'xlrd>=0.7.1',
     'sqlalchemy>=0.6.6',
-    'openpyxl==2.2.0-b1',
+    'openpyxl==2.2.0',
     'six>=1.6.1',
     'python-dateutil==2.2'
 ]


### PR DESCRIPTION
There's no branch for 0.9.1 so I'm opening this against master. openpyxl removed version 2.2.0-b1 which is breaking csvkit 0.9.1. I've tested 0.9.1 thoroughly in my software that depends on it (https://github.com/fishtown-analytics/dbt).

See: https://bitbucket.org/openpyxl/openpyxl/issues/1076/no-matching-distribution-found-for