### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "pypy" ]]; then pip install -r requirements-py2.txt; fi
@@ -14,5 +13,4 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install -r requirements-py3.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install -r requirements-py3.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install -r requirements-py3.txt; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.7" ]]; then pip install -r requirements-py3.txt; fi
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ python:
   - "pypy"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install -r requirements-py2.txt --use-mirrors --allow-external argparse; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "pypy" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install -r requirements-py3.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "3.4" ]]; then pip install -r requirements-py3.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install -r requirements-py3.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install -r requirements-py3.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.7" ]]; then pip install -r requirements-py3.txt; fi
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "pypy"
   - "3.3"
@@ -9,7 +8,6 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "pypy" ]]; then pip install -r requirements-py2.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install -r requirements-py3.txt; fi

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -5,7 +5,7 @@ python-dateutil==2.2
 SQLAlchemy>=0.9.3
 sphinx>=1.0.7
 coverage>=3.5.1b1
-openpyxl==2.2.0
+openpyxl==2.2.5
 tox>=1.3
 dbf==0.95.004
 unittest2==0.5.1

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -4,7 +4,7 @@ python-dateutil>=2.2
 SQLAlchemy>=0.9.3
 sphinx>=1.0.7
 coverage>=3.5.1b1
-openpyxl==2.2.0
+openpyxl==2.2.5
 tox>=1.3
 six>=1.6.1
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 install_requires = [
     'xlrd>=0.7.1',
     'sqlalchemy>=0.6.6',
-    'openpyxl==2.2.0',
+    'openpyxl==2.2.5',
     'six>=1.6.1',
     'python-dateutil==2.2'
 ]

--- a/tests/test_py2.py
+++ b/tests/test_py2.py
@@ -13,14 +13,14 @@ import csvkit
 @unittest.skipIf(six.PY3, "Not supported in Python 3.")
 class TestCSVKitReader(unittest.TestCase):
     def test_utf8(self):
-        with open('examples/test_utf8.csv') as f:
+        with open('examples/test_utf8.csv', 'rb') as f:
             reader = csvkit.CSVKitReader(f, encoding='utf-8')
             self.assertEqual(next(reader), ['a', 'b', 'c'])
             self.assertEqual(next(reader), ['1', '2', '3'])
             self.assertEqual(next(reader), ['4', '5', u'ʤ'])
 
     def test_reader_alias(self):
-        with open('examples/test_utf8.csv') as f:
+        with open('examples/test_utf8.csv', 'rb') as f:
             reader = csvkit.reader(f, encoding='utf-8')
             self.assertEqual(next(reader), ['a', 'b', 'c'])
             self.assertEqual(next(reader), ['1', '2', '3'])
@@ -120,4 +120,3 @@ class TestCSVKitDictWriter(unittest.TestCase):
         result = self.output.getvalue()
 
         self.assertEqual(result, 'a,b,c\n1,2,☃\n')
-


### PR DESCRIPTION
This branch:
- adds test support for Python 3.5, 3.6
- removes the now-unsupported Python 2.6
- upgrades openpyxl to 2.2.5, which has no breaking changes from 2.2.0 but includes bugfixes
- fixes a couple errors in the tests (`IOError: file must be opened in binary mode`)