### PR TITLE
Remove unnecessary dependency on unittest2

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -6,4 +6,3 @@ simplejson>=3.6.3
 
 # Development
 mock>=1.3.0
-unittest2==1.1.0

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from csvkit.cleanup import join_rows
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from csvkit.cli import match_column_identifier, parse_column_identifiers
 

--- a/tests/test_convert/test_convert.py
+++ b/tests/test_convert/test_convert.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from csvkit import convert
 

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 
 import re
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from csvkit.grep import FilteringCSVReader
 from csvkit.exceptions import ColumnIdentifierError

--- a/tests/test_utilities/test_csvjson.py
+++ b/tests/test_utilities/test_csvjson.py
@@ -58,7 +58,7 @@ class TestCSVJSON(CSVKitTestCase, EmptyFileTests):
         output = self.get_output(['-i', '4', 'examples/dummy.csv'])
         js = json.loads(output)
         self.assertDictEqual(js[0], {'a': True, 'c': 3.0, 'b': 2.0})
-        self.assertRegex(output, '        "a": true,')
+        six.assertRegex(self, output, '        "a": true,')
 
     def test_keying(self):
         js = json.loads(self.get_output(['-k', 'a', 'examples/dummy.csv']))
@@ -67,7 +67,9 @@ class TestCSVJSON(CSVKitTestCase, EmptyFileTests):
     def test_duplicate_keys(self):
         output_file = six.StringIO()
         utility = CSVJSON(['-k', 'a', 'examples/dummy3.csv'], output_file)
-        self.assertRaisesRegex(ValueError, 'Value True is not unique in the key column.', utility.run)
+        six.assertRaisesRegex(self, ValueError,
+                              'Value True is not unique in the key column.',
+                              utility.run)
         output_file.close()
 
     def test_geojson_with_id(self):

--- a/tests/test_utilities/test_csvstat.py
+++ b/tests/test_utilities/test_csvstat.py
@@ -2,6 +2,8 @@
 
 import sys
 
+import six
+
 import agate
 
 try:
@@ -47,11 +49,11 @@ class TestCSVStat(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
 
     def test_unique(self):
         output = self.get_output(['-c', 'county', 'examples/realdata/ks_1033_data.csv'])
-        self.assertRegex(output, r'Unique values:\s+73')
+        six.assertRegex(self, output, r'Unique values:\s+73')
 
     def test_max_length(self):
         output = self.get_output(['-c', 'county', 'examples/realdata/ks_1033_data.csv'])
-        self.assertRegex(output, r'Longest value:\s+12')
+        six.assertRegex(self, output, r'Longest value:\s+12')
 
     def test_freq_list(self):
         output = self.get_output(['examples/realdata/ks_1033_data.csv'])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,16 +20,12 @@ And paste:
 """
 
 import sys
+import unittest
 import warnings
 from contextlib import contextmanager
 
 import agate
 import six
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 from csvkit.exceptions import ColumnIdentifierError, RequiredHeaderError
 


### PR DESCRIPTION
csvkit doesn't support Python 2.6, so there is no need to use unittest2
which sole purpose is to bring unittest from Python 3.* (and 2.7) to
2.6.

Compatibility between 2.7 and 3.* API is provided by six (which is
already requirement for csvkit).

Fixes #978 