### PR TITLE
Allow one file argument to csvjoin. File is passed through

### DIFF
--- a/csvkit/utilities/csvjoin.py
+++ b/csvkit/utilities/csvjoin.py
@@ -33,8 +33,8 @@ class CSVJoin(CSVKitUtility):
         for path in self.args.input_paths:
             self.input_files.append(self._open_input_file(path))
 
-        if len(self.input_files) < 2:
-            self.argparser.error('You must specify at least two files to join.')
+        if len(self.input_files) < 1:
+            self.argparser.error('You must specify at least one file to join.')
 
         if self.args.columns:
             join_column_names = self._parse_join_column_names(self.args.columns)


### PR DESCRIPTION
This is to fix issue #998.

The help text for `csvjoin` states 
<pre>positional arguments:
  FILE                  The CSV files to operate on. If only one is specified,
                        it will be copied to STDOUT.</pre>

Currently, that's not true; instead `csvjoin` gives an error when called with only one argument.

Just eliminating the check lets it work, and single files are passed through fine. All tests still pass (I ran `python3 -m unittest` and discovery found 255 tests.)

