### PR TITLE
csvformat type inference for numbers

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -295,12 +295,13 @@ class CSVKitUtility(object):
             type_kwargs = {}
 
         text_type = agate.Text(**type_kwargs)
+        number_type = agate.Number(locale=self.args.locale, **type_kwargs)
 
-        if self.args.no_inference:
+        if getattr(self.args, 'no_inference', None):
             types = [text_type]
+        elif getattr(self.args, 'infer_only_numbers', None):
+            types = [number_type, text_type]
         else:
-            number_type = agate.Number(locale=self.args.locale, **type_kwargs)
-
             # See the order in the `agate.TypeTester` class.
             types = [
                 agate.Boolean(**type_kwargs),

--- a/tests/test_utilities/test_csvformat.py
+++ b/tests/test_utilities/test_csvformat.py
@@ -72,6 +72,17 @@ class TestCSVFormat(CSVKitTestCase, EmptyFileTests):
 
         input_file.close()
 
+    def test_numeric_inference(self):
+        input_file = six.StringIO('a,b,c\na,2,3\n')
+
+        with stdin_as_string(input_file):
+            self.assertLines(['-U', '2'], [
+                '"a","b","c"',
+                '"a",2,3',
+            ])
+
+        input_file.close()
+
     def test_escapechar(self):
         input_file = six.StringIO('a,b,c\n1"2,3,4\n')
 


### PR DESCRIPTION
just took a shot at solving this one!

https://github.com/wireservice/csvkit/issues/938

Like mentioned on the thread, it doesn't look like any type inference happens in csvformat at all. That said, in the quoted example `echo "A,B,1,2018" | csvformat -U 2`, to me quoting everything is probably correct because that's the header row? If you do `echo "A,B,1,2018" | csvformat -U 2 --no-header-row`, then the 1 and 2018 should not be quoted. 

Let me know if I can do anything on here more cleanly!