### PR TITLE
Fixed error when --no-header-row is combined with --groups/--filenames

### DIFF
--- a/csvkit/utilities/csvstack.py
+++ b/csvkit/utilities/csvstack.py
@@ -73,7 +73,7 @@ class CSVStack(CSVKitUtility):
             else:
                 row = next(rows, [])
 
-                headers = make_default_headers(len(row))
+                headers = list(make_default_headers(len(row)))
 
                 if i == 0:
                     if has_groups:

--- a/tests/test_utilities/test_csvstack.py
+++ b/tests/test_utilities/test_csvstack.py
@@ -53,9 +53,64 @@ class TestCSVStack(CSVKitTestCase, EmptyFileTests):
             ['dummy2.csv', '1', '2', '3'],
         ])
 
-    def test_no_header_row(self):
+class TestNoHeaderRow(TestCSVStack):
+
+    def test_no_header_row_basic(self):
         self.assertRows(['--no-header-row', 'examples/no_header_row.csv', 'examples/no_header_row2.csv'], [
             ['a', 'b', 'c'],
             ['1', '2', '3'],
             ['4', '5', '6'],
         ])
+
+    def test_grouped_manual_and_named_column(self):
+        self.assertRows(
+            [
+                "--no-header-row",
+                "--groups",
+                "foo,bar",
+                "-n",
+                "hey",
+                "examples/dummy.csv",
+                "examples/dummy3.csv",
+            ],
+            [
+                ["hey", "a", "b", "c"],
+                ["foo", "a", "b", "c"],
+                ["foo", "1", "2", "3"],
+                ["bar", "a", "b", "c"],
+                ["bar", "1", "2", "3"],
+                ["bar", "1", "4", "5"],
+            ],
+        )
+
+    def test_grouped_filenames(self):
+        self.assertRows(
+            [
+                "-H",
+                "--filenames",
+                "examples/no_header_row.csv",
+                "examples/no_header_row2.csv",
+            ],
+            [
+                ["group",                "a", "b", "c"],
+                ["no_header_row.csv",    "1", "2", "3"],
+                ["no_header_row2.csv",   "4", "5", "6"],
+            ],
+        )
+
+    def test_grouped_filenames_and_named_column(self):
+        self.assertRows(
+            [
+                "-H",
+                "--filenames",
+                "-n",
+                "hello",
+                "examples/no_header_row.csv",
+                "examples/no_header_row2.csv",
+            ],
+            [
+                ["hello", "a", "b", "c"],
+                ["no_header_row.csv", "1", "2", "3"],
+                ["no_header_row2.csv", "4", "5", "6"],
+            ],
+        )


### PR DESCRIPTION
In **csvstack**, an error occurred when combining the `--no-header-row` flag with either `--groups` or `--filenames`.

For example:

```sh
$ csvstack --filenames -H examples/dummy.csv examples/dummy2.csv --verbose
```

The expected (if funky) output is:

```
group,a,b,c
dummy.csv,a,b,c
dummy.csv,1,2,3
dummy2.csv,a,b,c
dummy2.csv,1,2,3
```

However, this error occurs:

```
Traceback (most recent call last):
  File "/Users/dan/.pyenv/versions/3.8.5/bin/csvstack", line 11, in <module>
    load_entry_point('csvkit', 'console_scripts', 'csvstack')()
  File "/Users/dan/git/csvkit/csvkit/utilities/csvstack.py", line 100, in launch_new_instance
    utility.run()
  File "/Users/dan/git/csvkit/csvkit/cli.py", line 118, in run
    self.main()
  File "/Users/dan/git/csvkit/csvkit/utilities/csvstack.py", line 80, in main
    headers.insert(0, group_name)
AttributeError: 'tuple' object has no attribute 'insert'
```

The cause of this error seems to be what [csvstack.py assumes when invoking `make_default_headers(...)`](https://github.com/wireservice/csvkit/blob/120d7c9d37d89d70b9c396b0994e2fa5f077a112/csvkit/utilities/csvstack.py#L76) – `make_default_headers` returns a tuple, but `csvstack` attempts to do `list#insert()`, which is not possible with a tuple:

```py
                headers = make_default_headers(len(row))

                if i == 0:
                    if has_groups:
                        headers.insert(0, group_name)
```

The fix is simple: cast the return value of `make_default_headers()` as a list:

```py
                headers = make_default_headers(len(row))
```

This pull request also includes 3 tests related to the `--no-header-row` option in addition to the existing `test_no_header_row_basic()` test. 

