### PR TITLE
Speedup `csvstat` by using a sniff-limit and faster `get_freq` implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 
 * fix: Restore Python 2.7 support in edge cases.
 * Drop Python 3.5 support (end-of-life was September 30, 2020).
+* improvement: use 1024 byte sniff-limit by default across csvkit. Improve csvstat performance up to 10x.
 
 1.0.6 - July 13, 2021
 ---------------------

--- a/csvkit/utilities/csvjoin.py
+++ b/csvkit/utilities/csvjoin.py
@@ -32,8 +32,9 @@ class CSVJoin(CSVKitUtility):
             help='Perform a right outer join, rather than the default inner join. If more than two files are provided '
                  'this will be executed as a sequence of right outer joins, starting at the right.')
         self.argparser.add_argument(
-            '-y', '--snifflimit', dest='sniff_limit', type=int,
-            help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing.')
+            '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
+            help='Limit CSV dialect sniffing to the specified number of bytes. '
+                 'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
         self.argparser.add_argument(
             '-I', '--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference when parsing CSV input.')
@@ -64,7 +65,7 @@ class CSVJoin(CSVKitUtility):
             self.argparser.error('It is not valid to specify both a left and a right join.')
 
         tables = []
-        sniff_limit = self.args.sniff_limit
+        sniff_limit = self.args.sniff_limit if self.args.sniff_limit != -1 else None
         column_types = self.get_column_types()
 
         for f in self.input_files:

--- a/csvkit/utilities/csvjson.py
+++ b/csvkit/utilities/csvjson.py
@@ -55,8 +55,9 @@ class CSVJSON(CSVKitUtility):
             '--stream', dest='streamOutput', action='store_true',
             help='Output JSON as a stream of newline-separated objects, rather than an as an array.')
         self.argparser.add_argument(
-            '-y', '--snifflimit', dest='sniff_limit', type=int,
-            help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing.')
+            '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
+            help='Limit CSV dialect sniffing to the specified number of bytes. '
+                 'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
         self.argparser.add_argument(
             '-I', '--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference (and --locale, --date-format, --datetime-format) when parsing CSV input.')
@@ -141,10 +142,11 @@ class CSVJSON(CSVKitUtility):
             self.argparser.error('--key is only allowed with --stream when --lat and --lon are also specified.')
 
     def read_csv_to_table(self):
+        sniff_limit = self.args.sniff_limit if self.args.sniff_limit != -1 else None
         return agate.Table.from_csv(
             self.input_file,
             skip_lines=self.args.skip_lines,
-            sniff_limit=self.args.sniff_limit,
+            sniff_limit=sniff_limit,
             column_types=self.get_column_types(),
             **self.reader_kwargs
         )

--- a/csvkit/utilities/csvlook.py
+++ b/csvkit/utilities/csvlook.py
@@ -19,8 +19,9 @@ class CSVLook(CSVKitUtility):
             '--max-column-width', dest='max_column_width', type=int,
             help='Truncate all columns to at most this width. The remainder will be replaced with ellipsis.')
         self.argparser.add_argument(
-            '-y', '--snifflimit', dest='sniff_limit', type=int,
-            help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing.')
+            '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
+            help='Limit CSV dialect sniffing to the specified number of bytes. '
+                 'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
         self.argparser.add_argument(
             '-I', '--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference when parsing the input.')
@@ -29,10 +30,11 @@ class CSVLook(CSVKitUtility):
         if self.additional_input_expected():
             self.argparser.error('You must provide an input file or piped data.')
 
+        sniff_limit = self.args.sniff_limit if self.args.sniff_limit != -1 else None
         table = agate.Table.from_csv(
             self.input_file,
             skip_lines=self.args.skip_lines,
-            sniff_limit=self.args.sniff_limit,
+            sniff_limit=sniff_limit,
             column_types=self.get_column_types(),
             line_numbers=self.args.line_numbers,
             **self.reader_kwargs

--- a/csvkit/utilities/csvsort.py
+++ b/csvkit/utilities/csvsort.py
@@ -20,8 +20,9 @@ class CSVSort(CSVKitUtility):
             '-r', '--reverse', dest='reverse', action='store_true',
             help='Sort in descending order.')
         self.argparser.add_argument(
-            '-y', '--snifflimit', dest='sniff_limit', type=int,
-            help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing.')
+            '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
+            help='Limit CSV dialect sniffing to the specified number of bytes. '
+                 'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
         self.argparser.add_argument(
             '-I', '--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference when parsing the input.')
@@ -34,10 +35,11 @@ class CSVSort(CSVKitUtility):
         if self.additional_input_expected():
             self.argparser.error('You must provide an input file or piped data.')
 
+        sniff_limit = self.args.sniff_limit if self.args.sniff_limit != -1 else None
         table = agate.Table.from_csv(
             self.input_file,
             skip_lines=self.args.skip_lines,
-            sniff_limit=self.args.sniff_limit,
+            sniff_limit=sniff_limit,
             column_types=self.get_column_types(),
             **self.reader_kwargs
         )

--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -69,8 +69,9 @@ class CSVSQL(CSVKitUtility):
             '--db-schema', dest='db_schema',
             help='Optional name of database schema to create table(s) in.')
         self.argparser.add_argument(
-            '-y', '--snifflimit', dest='sniff_limit', type=int,
-            help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing.')
+            '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
+            help='Limit CSV dialect sniffing to the specified number of bytes. '
+                 'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
         self.argparser.add_argument(
             '-I', '--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference when parsing the input.')
@@ -168,12 +169,13 @@ class CSVSQL(CSVKitUtility):
                     table_name = os.path.splitext(os.path.basename(f.name))[0]
 
             table = None
+            sniff_limit = self.args.sniff_limit if self.args.sniff_limit != -1 else None
 
             try:
                 table = agate.Table.from_csv(
                     f,
                     skip_lines=self.args.skip_lines,
-                    sniff_limit=self.args.sniff_limit,
+                    sniff_limit=sniff_limit,
                     column_types=self.get_column_types(),
                     **self.reader_kwargs
                 )

--- a/csvkit/utilities/in2csv.py
+++ b/csvkit/utilities/in2csv.py
@@ -57,8 +57,9 @@ class In2CSV(CSVKitUtility):
             '--encoding-xls', dest='encoding_xls',
             help='Specify the encoding of the input XLS file.')
         self.argparser.add_argument(
-            '-y', '--snifflimit', dest='sniff_limit', type=int,
-            help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing.')
+            '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
+            help='Limit CSV dialect sniffing to the specified number of bytes. '
+                 'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
         self.argparser.add_argument(
             '-I', '--no-inference', dest='no_inference', action='store_true',
             help='Disable type inference (and --locale, --date-format, --datetime-format) when parsing CSV input.')
@@ -116,6 +117,7 @@ class In2CSV(CSVKitUtility):
 
         # Set the reader's arguments.
         kwargs = {}
+        sniff_limit = self.args.sniff_limit if self.args.sniff_limit != -1 else None
 
         if self.args.schema:
             schema = self._open_input_file(self.args.schema)
@@ -124,7 +126,7 @@ class In2CSV(CSVKitUtility):
 
         if filetype == 'csv':
             kwargs.update(self.reader_kwargs)
-            kwargs['sniff_limit'] = self.args.sniff_limit
+            kwargs['sniff_limit'] = sniff_limit
 
         if filetype in ('xls', 'xlsx'):
             kwargs['header'] = not self.args.no_header_row
@@ -141,7 +143,7 @@ class In2CSV(CSVKitUtility):
             and self.args.no_inference
             and not self.args.no_header_row
             and not self.args.skip_lines
-            and self.args.sniff_limit == 0
+            and sniff_limit == 0
         ):
             reader = agate.csv.reader(self.input_file, **self.reader_kwargs)
             writer = agate.csv.writer(self.output_file, **self.writer_kwargs)

--- a/tests/test_utilities/test_csvclean.py
+++ b/tests/test_utilities/test_csvclean.py
@@ -18,6 +18,11 @@ from tests.utils import CSVKitTestCase, EmptyFileTests
 class TestCSVClean(CSVKitTestCase, EmptyFileTests):
     Utility = CSVClean
 
+    def tearDown(self):
+        output_file = "stdin_out.csv"
+        if os.path.isfile(output_file):
+            os.remove(output_file)
+
     def assertCleaned(self, basename, output_lines, error_lines, additional_args=[]):
         args = ['examples/%s.csv' % basename] + additional_args
         output_file = six.StringIO()


### PR DESCRIPTION
I use `csvkit` a lot and absolutely love it. `csvkit` (and `csvstat` in particular) can be very slow on large CSVs, and I decided to look into it. I used [snakeviz](https://jiffyclub.github.io/snakeviz/) to poke around.

```bash
# Download a large dataset
~/Code/csvkit (master) $ curl https://www.stats.govt.nz/assets/Uploads/Annual-enterprise-survey/Annual-enterprise-survey-2020-financial-year-provisional/Download-data/annual-enterprise-survey-2020-financial-year-provisional-csv.csv > nz.csv
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5743k  100 5743k    0     0   742k      0  0:00:07  0:00:07 --:--:--  924k

# See performance on master (~24 seconds)
~/Code/csvkit (master) $ time csvstat nz.csv > before.txt
csvstat nz.csv > before.txt  24.07s user 0.20s system 98% cpu 24.591 total

# See performance on feature branch (~2.6 seconds)
~/Code/csvkit (master) $ git checkout sniff-limit
Switched to branch 'sniff-limit'
~/Code/csvkit (sniff-limit) $ time csvstat nz.csv > after.txt
csvstat nz.csv > after.txt  2.38s user 0.15s system 96% cpu 2.629 total

# Check contents are identical
~/Code/csvkit (sniff-limit) $ diff before.txt after.txt
~/Code/csvkit (sniff-limit) $
```

This results in a 10x speedup for very large CSVs! I'll write some notes by each change I'm making.