### PR TITLE
Add support for .xz files in Python 3.

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -12,6 +12,9 @@ from os.path import splitext
 import agate
 import six
 
+if six.PY3:
+    import lzma
+
 from csvkit.exceptions import ColumnIdentifierError, RequiredHeaderError
 
 
@@ -251,6 +254,11 @@ class CSVKitUtility(object):
                     f = LazyFile(bz2.BZ2File, path, mode, **kwargs)
                 else:
                     f = LazyFile(bz2.open, path, mode, **kwargs)
+            elif extension == ".xz":
+                if six.PY2:
+                    raise RuntimeError("Cannot read .xz files with Python 2")
+                else:
+                    f = LazyFile(lzma.open, path, mode, **kwargs)
             else:
                 f = LazyFile(open, path, mode, **kwargs)
 

--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -14,6 +14,12 @@ import six
 
 if six.PY3:
     import lzma
+elif six.PY2:
+    # Try import backports.lzma if available
+    try:
+        from backports import lzma
+    except ImportError:
+        lzma = None
 
 from csvkit.exceptions import ColumnIdentifierError, RequiredHeaderError
 
@@ -255,10 +261,10 @@ class CSVKitUtility(object):
                 else:
                     f = LazyFile(bz2.open, path, mode, **kwargs)
             elif extension == ".xz":
-                if six.PY2:
-                    raise RuntimeError("Cannot read .xz files with Python 2")
-                else:
+                if lzma is not None:
                     f = LazyFile(lzma.open, path, mode, **kwargs)
+                else:
+                    raise RuntimeError("backports.lzma is needed for .xz support with Python 2")
             else:
                 f = LazyFile(open, path, mode, **kwargs)
 


### PR DESCRIPTION
Python 3 standard library has support LZMA decompression used in XZ format. Since LZMA library is not available for Python 2, an error is raised when trying to read .xz on Python 2.

Happy for any feedback. 