### PR TITLE
Add decimal formatting to csvstat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
       - run: flake8 .
       - run: isort . --check-only
       - run: pip install .[test] coveralls
-      - run: pytest --cov csvkit
-        env:
+      - env:
+          LANG: en_US.UTF-8
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: 1
+        run: pytest --cov csvkit
       # CoverallsException: Not on TravisCI. You have to provide either repo_token in .coveralls.yml or set the COVERALLS_REPO_TOKEN env var.
       - if: matrix.python-version != '2.7'
         env:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -105,3 +105,4 @@ The following individuals have contributed code to csvkit:
 * Bonifacio de Oliveira
 * Ryan Grout
 * badbunnyyy
+* Werner Robitza

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -104,3 +104,4 @@ The following individuals have contributed code to csvkit:
 * Christian Clauss
 * Bonifacio de Oliveira
 * Ryan Grout
+* badbunnyyy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 * feat: :doc:`/scripts/csvsql` accepts multiple :code:`--query` command-line arguments.
+* feat: :doc:`/scripts/csvstat` adds :code:`--no-grouping-separator` and :code:`--decimal-format` options.
 
 1.0.7 - March 6, 2022
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,15 @@
+Unreleased
+----------
+
+* feat: :doc:`/scripts/csvsql` accepts multiple :code:`--query` command-line arguments.
+
 1.0.7 - March 6, 2022
 ---------------------
 
 * fix: :doc:`/scripts/csvcut` extracts the correct columns when :code:`--line-numbers` is set.
 * fix: Restore Python 2.7 support in edge cases.
-* improvement: Use 1024 byte sniff-limit by default across csvkit. Improve csvstat performance up to 10x.
-* improvement: Add support for ``.xz`` (LZMA) compressed input files.
+* feat: Use 1024 byte sniff-limit by default across csvkit. Improve csvstat performance up to 10x.
+* feat: Add support for ``.xz`` (LZMA) compressed input files.
 * Add Python 3.10 support.
 * Drop Python 3.5 support (end-of-life was September 30, 2020).
 

--- a/csvkit/utilities/csvstat.py
+++ b/csvkit/utilities/csvstat.py
@@ -115,6 +115,13 @@ class CSVStat(CSVKitUtility):
             '--count', dest='count_only', action='store_true',
             help='Only output total row count.')
         self.argparser.add_argument(
+            '--decimal-format', dest='decimal_format', type=str, default='%.3f',
+            help='%%-format specification for printing decimal numbers. '
+                 'Defaults to locale-specific formatting with \'%%.3f\'.')
+        self.argparser.add_argument(
+            '-G', '--no-grouping-separator', dest='no_grouping_separator',
+            action='store_true', help='Do not add group separators when printing large decimal numbers. ')
+        self.argparser.add_argument(
             '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
             help='Limit CSV dialect sniffing to the specified number of bytes. '
                  'Specify "0" to disable sniffing entirely, or "-1" to sniff the entire file.')
@@ -215,7 +222,7 @@ class CSVStat(CSVKitUtility):
                     stat = table.aggregate(op(column_id))
 
                     if self.is_finite_decimal(stat):
-                        stat = format_decimal(stat)
+                        stat = format_decimal(stat, self.args.decimal_format, self.args.no_grouping_separator)
             except Exception:
                 stat = None
 
@@ -249,7 +256,7 @@ class CSVStat(CSVKitUtility):
                         v = table.aggregate(op(column_id))
 
                         if self.is_finite_decimal(v):
-                            v = format_decimal(v)
+                            v = format_decimal(v, self.args.decimal_format, self.args.no_grouping_separator)
 
                         stats[op_name] = v
                 except Exception:
@@ -293,7 +300,7 @@ class CSVStat(CSVKitUtility):
                             v = row['value']
 
                             if self.is_finite_decimal(v):
-                                v = format_decimal(v)
+                                v = format_decimal(v, self.args.decimal_format, self.args.no_grouping_separator)
                         else:
                             v = six.text_type(row['value'])
 
@@ -345,8 +352,8 @@ class CSVStat(CSVKitUtility):
             writer.writerow(output_row)
 
 
-def format_decimal(d):
-    return locale.format_string('%.3f', d, grouping=True).rstrip('0').rstrip('.')
+def format_decimal(d, f='%.3f', no_grouping_separator=False):
+    return locale.format_string(f, d, grouping=not no_grouping_separator).rstrip('0').rstrip('.')
 
 
 def get_type(table, column_id, **kwargs):

--- a/csvkit/utilities/csvstat.py
+++ b/csvkit/utilities/csvstat.py
@@ -117,10 +117,10 @@ class CSVStat(CSVKitUtility):
         self.argparser.add_argument(
             '--decimal-format', dest='decimal_format', type=str, default='%.3f',
             help='%%-format specification for printing decimal numbers. '
-                 'Defaults to locale-specific formatting with \'%%.3f\'.')
+                 'Defaults to locale-specific formatting with "%%.3f".')
         self.argparser.add_argument(
-            '-G', '--no-grouping-separator', dest='no_grouping_separator',
-            action='store_true', help='Do not add group separators when printing large decimal numbers. ')
+            '-G', '--no-grouping-separator', dest='no_grouping_separator', action='store_true',
+            help='Do not use grouping separators in decimal numbers.')
         self.argparser.add_argument(
             '-y', '--snifflimit', dest='sniff_limit', type=int, default=1024,
             help='Limit CSV dialect sniffing to the specified number of bytes. '

--- a/docs/scripts/csvstat.rst
+++ b/docs/scripts/csvstat.rst
@@ -12,7 +12,8 @@ Prints descriptive statistics for all columns in a CSV file. Will intelligently 
                    [-K SKIP_LINES] [-v] [-l] [--zero] [-V] [--csv] [-n]
                    [-c COLUMNS] [--type] [--nulls] [--unique] [--min] [--max]
                    [--sum] [--mean] [--median] [--stdev] [--len] [--freq]
-                   [--freq-count FREQ_COUNT] [--count] [-y SNIFF_LIMIT]
+                   [--freq-count FREQ_COUNT] [--count]  [--decimal-format DECIMAL_FORMAT]
+                   [-G] [-y SNIFF_LIMIT]
                    [FILE]
 
     Print descriptive statistics for each column in a CSV file.
@@ -44,6 +45,11 @@ Prints descriptive statistics for all columns in a CSV file. Will intelligently 
       --freq-count FREQ_COUNT
                             The maximum number of frequent values to display.
       --count               Only output total row count.
+      --decimal-format DECIMAL_FORMAT
+                            %-format specification for printing decimal numbers.
+                            Defaults to locale-specific formatting with '%.3f'.
+      -G, --no-grouping-separator
+                            Do not add group separators when printing large decimal numbers. 
       -y SNIFF_LIMIT, --snifflimit SNIFF_LIMIT
                             Limit CSV dialect sniffing to the specified number of
                             bytes. Specify "0" to disable sniffing.

--- a/docs/scripts/csvstat.rst
+++ b/docs/scripts/csvstat.rst
@@ -47,9 +47,9 @@ Prints descriptive statistics for all columns in a CSV file. Will intelligently 
       --count               Only output total row count.
       --decimal-format DECIMAL_FORMAT
                             %-format specification for printing decimal numbers.
-                            Defaults to locale-specific formatting with '%.3f'.
+                            Defaults to locale-specific formatting with "%.3f".
       -G, --no-grouping-separator
-                            Do not add group separators when printing large decimal numbers. 
+                            Do not use grouping separators in decimal numbers.
       -y SNIFF_LIMIT, --snifflimit SNIFF_LIMIT
                             Limit CSV dialect sniffing to the specified number of
                             bytes. Specify "0" to disable sniffing.

--- a/tests/test_utilities/test_csvstat.py
+++ b/tests/test_utilities/test_csvstat.py
@@ -114,10 +114,14 @@ class TestCSVStat(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
 
         self.assertIn('9,748.346', output)
 
-        output = self.get_output(['-c', 'TOTAL', '--mean', '--no-grouping-separator', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'])
+        output = self.get_output([
+            '-c', 'TOTAL', '--mean', '--no-grouping-separator', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'
+        ])
 
         self.assertIn('9748.346', output)
 
-        output = self.get_output(['-c', 'TOTAL', '--mean', '--decimal-format', '%.2f', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'])
+        output = self.get_output([
+            '-c', 'TOTAL', '--mean', '--decimal-format', '%.2f', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'
+        ])
 
         self.assertIn('9,748.35', output)

--- a/tests/test_utilities/test_csvstat.py
+++ b/tests/test_utilities/test_csvstat.py
@@ -112,16 +112,16 @@ class TestCSVStat(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
     def test_decimal_format(self):
         output = self.get_output(['-c', 'TOTAL', '--mean', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'])
 
-        self.assertIn('9,748.346', output)
+        self.assertEqual(output, '9,748.346\n')
 
         output = self.get_output([
             '-c', 'TOTAL', '--mean', '--no-grouping-separator', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'
         ])
 
-        self.assertIn('9748.346', output)
+        self.assertEqual(output, '9748.346\n')
 
         output = self.get_output([
             '-c', 'TOTAL', '--mean', '--decimal-format', '%.2f', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'
         ])
 
-        self.assertIn('9,748.35', output)
+        self.assertEqual(output, '9,748.35\n')

--- a/tests/test_utilities/test_csvstat.py
+++ b/tests/test_utilities/test_csvstat.py
@@ -108,3 +108,16 @@ class TestCSVStat(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
         self.assertEqual(row[2], 'Text')
         self.assertEqual(row[5], '')
         self.assertEqual(row[11], '16')
+
+    def test_decimal_format(self):
+        output = self.get_output(['-c', 'TOTAL', '--mean', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'])
+
+        self.assertIn('9,748.346', output)
+
+        output = self.get_output(['-c', 'TOTAL', '--mean', '--no-grouping-separator', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'])
+
+        self.assertIn('9748.346', output)
+
+        output = self.get_output(['-c', 'TOTAL', '--mean', '--decimal-format', '%.2f', 'examples/realdata/FY09_EDU_Recipients_by_State.csv'])
+
+        self.assertIn('9,748.35', output)


### PR DESCRIPTION
This allows users to specify a different decimal %-format syntax.
Grouping of numbers can be optionally disabled.