### PR TITLE
Use importlib.metadata instead of pkg_resources in python 3.10 and above

### DIFF
--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -5,12 +5,16 @@ import sys
 
 import agate
 import agatesql  # noqa: F401
-from pkg_resources import iter_entry_points
 from sqlalchemy import create_engine, dialects
 
 from csvkit.cli import CSVKitUtility, isatty
 
-DIALECTS = dialects.__all__ + tuple(e.name for e in iter_entry_points('sqlalchemy.dialects'))
+if sys.version_info < (3, 10):
+    from pkg_resources import iter_entry_points
+    DIALECTS = dialects.__all__ + tuple(e.name for e in iter_entry_points('sqlalchemy.dialects'))
+else:
+    from importlib.metadata import entry_points
+    DIALECTS = dialects.__all__ + tuple(e.name for e in entry_points(group='sqlalchemy.dialects'))
 
 
 class CSVSQL(CSVKitUtility):


### PR DESCRIPTION
This PR suppress a deprecation warning.

before:
```sh
$ SQLALCHEMY_SILENCE_UBER_WARNING=1 csvsql --query 'SELECT * FROM dummy' examples/dummy.csv
/home/kit494way/projects/csvkit/.venv/lib/python3.10/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
a,b,c
1,2.0,3.0
```

after:
```sh
$ SQLALCHEMY_SILENCE_UBER_WARNING=1 csvsql --query 'SELECT * FROM dummy' examples/dummy.csv
a,b,c
1,2.0,3.0
```