### PR TITLE
feat: build man pages on release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - run: pip install --upgrade -r docs/requirements.txt
+      - run: make -C docs man
       - run: pip install --upgrade build
       - run: python -m build --sdist --wheel
       - name: Publish to TestPyPI

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.rst
 include COPYING
 recursive-include docs *.py
+recursive-include docs *.1
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile


### PR DESCRIPTION
Resolves #1234

I tested via running the commands from `.github/workflows/pypi.yml` locally, and verified the man pages got included in my built tarball.