### PR TITLE
Fix typos across docs, manpages, and code (crate→create, accomodate→a…

### DIFF
--- a/docs/scripts/csvlook.rst
+++ b/docs/scripts/csvlook.rst
@@ -56,7 +56,7 @@ See also: :doc:`../common_arguments`.
 
 .. note::
 
-   The fractional part of a decimal numberal is always truncated. To control this truncation, use ``--no-inference`` along with ``--max-column-width``.
+   The fractional part of a decimal numeral is always truncated. To control this truncation, use ``--no-inference`` along with ``--max-column-width``.
 
 Examples
 ========

--- a/docs/scripts/csvsql.rst
+++ b/docs/scripts/csvsql.rst
@@ -33,7 +33,7 @@ Generate SQL statements for a CSV file or execute those statements directly on a
 
    optional arguments:
      -h, --help            show this help message and exit
-     -i {mssql,mysql,oracle,postgresql,sqlite,duckdb,crate,ingres}, --dialect {mssql,mysql,oracle,postgresql,sqlite,duckdb,crate,ingres}
+     -i {mssql,mysql,oracle,postgresql,sqlite,duckdb,create,ingres}, --dialect {mssql,mysql,oracle,postgresql,sqlite,duckdb,crate,ingres}
                            Dialect of SQL to generate. Cannot be used with --db.
      --db CONNECTION_STRING
                            If present, a SQLAlchemy connection string to use to
@@ -91,7 +91,7 @@ Generate SQL statements for a CSV file or execute those statements directly on a
                            The minimum length of text columns.
      --col-len-multiplier COL_LEN_MULTIPLIER
                            Multiply the maximum column length by this multiplier
-                           to accomodate larger values in later runs.
+                           to accommodate larger values in later runs.
 
 
 See also: :doc:`../common_arguments`.

--- a/man/csvclean.1
+++ b/man/csvclean.1
@@ -35,7 +35,7 @@ csvclean \- csvclean Documentation
 Reports and fixes common errors in a CSV file.
 .SS Checks
 .INDENT 0.0
-.IP \(bu 2
+.IP \(by 2
 Reports rows that have a different number of columns than the header row, if the \fB\-\-length\-mismatch\fP option is set.
 .IP \(bu 2
 Reports columns that are empty, if the \fB\-\-empty\-columns\fP option is set.

--- a/man/csvsql.1
+++ b/man/csvsql.1
@@ -120,7 +120,7 @@ optional arguments:
                         The minimum length of text columns.
   \-\-col\-len\-multiplier COL_LEN_MULTIPLIER
                         Multiply the maximum column length by this multiplier
-                        to accomodate larger values in later runs.
+                        to accommodate larger values in later runs.
 .ft P
 .fi
 .UNINDENT


### PR DESCRIPTION
…ccommodate, etc.)