### PR TITLE
FilteringCSVReader crashes on empty input when header mode is enabled

### DIFF
--- a/csvkit/cleanup.py
+++ b/csvkit/cleanup.py
@@ -63,12 +63,15 @@ class RowChecker:
         self.zero_based = zero_based
         self.omit_error_rows = omit_error_rows
 
+        self._exhausted = False
+
         try:
             self.column_names = next(reader)
             if header_normalize_space:
                 self.column_names = [' '.join(column_name.split()) for column_name in self.column_names]
         except StopIteration:
             self.column_names = []
+            self._exhausted = True
 
         self.errors = []
 
@@ -76,6 +79,9 @@ class RowChecker:
         """
         A generator which yields rows which are ready to write to output.
         """
+        if self._exhausted:
+            return
+
         len_column_names = len(self.column_names)
         joinable_row_errors = []
 

--- a/csvkit/grep.py
+++ b/csvkit/grep.py
@@ -37,9 +37,15 @@ class FilteringCSVReader:
 
         self.reader = reader
         self.header = header
+        self.returned_header = False
+        self._exhausted = False
 
         if self.header:
-            self.column_names = next(reader)
+            try:
+                self.column_names = next(reader)
+            except StopIteration:
+                self.column_names = None
+                self._exhausted = True
 
         self.any_match = any_match
         self.inverse = inverse
@@ -49,7 +55,10 @@ class FilteringCSVReader:
         return self
 
     def __next__(self):
-        if self.column_names and not self.returned_header:
+        if self._exhausted:
+            raise StopIteration()
+
+        if self.column_names is not None and not self.returned_header:
             self.returned_header = True
             return self.column_names
 


### PR DESCRIPTION
## Summary

In `FilteringCSVReader.__init__`, `next(reader)` is called unguarded when `header=True` (the default). If the upstream CSV iterator is empty, this raises `StopIteration` during object construction, causing an immediate crash instead of behaving like an empty iterator. In CLI usage, this turns a valid edge case (empty file/stream) into a hard failure.

## Files changed

- `csvkit/grep.py` (modified)
- `csvkit/cleanup.py` (modified)

## Testing

- Not run in this environment.
