### PR TITLE
join_rows assumes non-empty input and can raise IndexError

### DIFF
--- a/csvkit/cleanup.py
+++ b/csvkit/cleanup.py
@@ -17,6 +17,9 @@ def join_rows(rows, separator):
         The string with which to join the cells.
     """
     rows = list(rows)
+    if not rows:
+        return []
+
     fixed_row = rows[0][:]
 
     for row in rows[1:]:


### PR DESCRIPTION
## Summary

`join_rows` immediately accesses `rows[0]` after materializing the iterable. If an empty iterable is passed, this raises `IndexError`. This is a brittle failure mode in cleanup code paths and can crash processing instead of returning a controlled result.

## Files changed

- `csvkit/cleanup.py` (modified)

## Testing

- Not run in this environment.
