### PR TITLE
Make type inference treat underscore-containing numerics as text (not numbers)

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -29,6 +29,14 @@ except ImportError:
 QUOTING_CHOICES = sorted(getattr(csv, name) for name in dir(csv) if name.startswith('QUOTE_'))
 
 
+class UnderscoreDisallowingNumber(agate.Number):
+    def cast(self, d):
+        if isinstance(d, str) and '_' in d and not self.is_null(d):
+            raise agate.exceptions.CastError()
+
+        return super().cast(d)
+
+
 class LazyFile:
     """
     A proxy for a File object that delays opening it until
@@ -362,7 +370,7 @@ class CSVKitUtility:
         if getattr(self.args, 'no_inference', None):
             types = [text_type]
         else:
-            number_type = agate.Number(
+            number_type = UnderscoreDisallowingNumber(
                 locale=self.args.locale, no_leading_zeroes=getattr(self.args, 'no_leading_zeroes', None), **type_kwargs
             )
 


### PR DESCRIPTION
## Summary

The root cause is that `Decimal` accepts `_` as a grouping character, so inferred numeric fields like `100_1` are silently normalized to `1001`. The safest fix is at the shared inference layer in `csvkit/cli.py` (used by all utilities), by customizing numeric inference/casting behavior to reject underscore-containing values during type inference. This preserves original string values for ID-like fields and avoids silent mutation.

## Files changed

- `csvkit/cli.py` (modified)

## Testing

- Not run in this environment.


Closes #1246