### PR TITLE
Add `--ignore-unknown` flag to `csvcut` and wire it into column selection

### DIFF
--- a/csvkit/utilities/csvcut.py
+++ b/csvkit/utilities/csvcut.py
@@ -33,6 +33,9 @@ class CSVCut(CSVKitUtility):
             help='A comma-separated list of column indices, names or ranges to be excluded, e.g. "1,id,3-5". '
                  'Defaults to no columns.')
         self.argparser.add_argument(
+            '--ignore-unknown', dest='ignore_unknown', action='store_true',
+            help='Silently ignore unknown column identifiers in --columns.')
+        self.argparser.add_argument(
             '-x', '--delete-empty-rows', dest='delete_empty', action='store_true',
             help='After cutting, delete rows which are completely empty.')
 
@@ -44,7 +47,10 @@ class CSVCut(CSVKitUtility):
         if self.additional_input_expected():
             sys.stderr.write('No input file or piped data provided. Waiting for standard input:\n')
 
-        rows, column_names, column_ids = self.get_rows_and_column_names_and_column_ids(**self.reader_kwargs)
+        rows, column_names, column_ids = self.get_rows_and_column_names_and_column_ids(
+            ignore_unknown_columns=self.args.ignore_unknown,
+            **self.reader_kwargs,
+        )
 
         output = agate.csv.writer(self.output_file, **self.writer_kwargs)
         output.writerow([column_names[column_id] for column_id in column_ids])

--- a/tests/test_utilities/test_csvcut.py
+++ b/tests/test_utilities/test_csvcut.py
@@ -61,6 +61,12 @@ class TestCSVCut(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
             ['2', '3'],
         ])
 
+    def test_ignore_unknown_columns(self):
+        self.assertRows(['-c', '1,foo,3', '--ignore-unknown', 'examples/dummy.csv'], [
+            ['a', 'c'],
+            ['1', '3'],
+        ])
+
     def test_include_and_exclude(self):
         self.assertRows(['-c', '1,3', '-C', '3', 'examples/dummy.csv'], [
             ['a'],


### PR DESCRIPTION
## Summary

`csvcut` needs a new CLI option that changes `-c/--columns` behavior from “fail on unknown column identifier” to “silently skip unknown identifiers.” This is the core behavior requested in the issue. The change should be isolated to `csvcut` so other utilities keep current strict behavior by default.

## Files changed

- `csvkit/utilities/csvcut.py` (modified)
- `tests/test_utilities/test_csvcut.py` (modified)

## Testing

- Not run in this environment.


Closes #1288