### PR TITLE
feat(csvcut): add --ignore-unknown-columns option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Unreleased
 
 -  feat: :doc:`/scripts/csvcut` adds an :code:`--ignore-unknown-columns` option to skip identifiers in :code:`-c/--columns` that do not match a column in the input.
 -  feat: :doc:`/scripts/csvclean` adds a :code:`--remove-empty-columns` option to remove empty columns from standard output.
+-  fix: :code:`-C/--not-columns` now excludes the last column of an open-ended range (e.g. :code:`2-`).
 
 2.2.0 - December 15, 2025
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+-  feat: :doc:`/scripts/csvcut` adds an :code:`--ignore-unknown-columns` option to skip identifiers in :code:`-c/--columns` that do not match a column in the input.
+
 2.2.0 - December 15, 2025
 -------------------------
 

--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -513,6 +513,46 @@ def match_column_identifier(column_names, c, column_offset=1):
     return c
 
 
+def _resolve_column_identifier(identifier, column_names, column_offset, ignore_unknown_columns, ignore_invalid_range):
+    """
+    Resolve a single column identifier (a name, a 1-based index, or an integer range) to a list of indices.
+
+    An unmatched name or index is skipped if ``ignore_unknown_columns`` is set, and raises otherwise. A
+    malformed range, or a range that references a nonexistent column, is skipped if ``ignore_invalid_range``
+    is set, and raises otherwise.
+    """
+    try:
+        return [match_column_identifier(column_names, identifier, column_offset)]
+    except ColumnIdentifierError:
+        if ':' in identifier:
+            a, b = identifier.split(':', 1)
+        elif '-' in identifier:
+            a, b = identifier.split('-', 1)
+        elif ignore_unknown_columns:
+            return []
+        else:
+            raise
+
+        try:
+            a = int(a) if a else 1
+            b = int(b) + 1 if b else len(column_names) + 1
+        except ValueError:
+            if ignore_invalid_range:
+                return []
+            raise ColumnIdentifierError(
+                "Invalid range %s. Ranges must be two integers separated by a - or : character." % identifier)
+
+        indices = []
+        for index in range(a, b):
+            try:
+                indices.append(match_column_identifier(column_names, index, column_offset))
+            except ColumnIdentifierError:
+                if ignore_invalid_range:
+                    continue
+                raise
+        return indices
+
+
 def parse_column_identifiers(ids, column_names, column_offset=1, excluded_columns=None, ignore_unknown_columns=False):
     """
     Parse a comma-separated list of column indices AND/OR names into a list of integer indices.
@@ -528,65 +568,34 @@ def parse_column_identifiers(ids, column_names, column_offset=1, excluded_column
 
     if ids:
         columns = []
-
-        for c in ids.split(','):
-            try:
-                columns.append(match_column_identifier(column_names, c, column_offset))
-            except ColumnIdentifierError:
-                if ':' in c:
-                    a, b = c.split(':', 1)
-                elif '-' in c:
-                    a, b = c.split('-', 1)
-                else:
-                    if ignore_unknown_columns:
-                        continue
-                    raise
-
-                try:
-                    a = int(a) if a else 1
-                    b = int(b) + 1 if b else len(column_names) + 1
-                except ValueError:
-                    if ignore_unknown_columns:
-                        continue
-                    raise ColumnIdentifierError(
-                        "Invalid range %s. Ranges must be two integers separated by a - or : character." % c)
-
-                for x in range(a, b):
-                    try:
-                        columns.append(match_column_identifier(column_names, x, column_offset))
-                    except ColumnIdentifierError:
-                        if ignore_unknown_columns:
-                            continue
-                        raise
+        for identifier in ids.split(','):
+            columns.extend(
+                _resolve_column_identifier(
+                    column_names=column_names,
+                    identifier=identifier,
+                    column_offset=column_offset,
+                    ignore_unknown_columns=ignore_unknown_columns,
+                    ignore_invalid_range=ignore_unknown_columns,
+                )
+            )
     else:
         columns = range(len(column_names))
 
     excludes = []
-
     if excluded_columns:
-        for c in excluded_columns.split(','):
-            try:
-                excludes.append(match_column_identifier(column_names, c, column_offset))
-            except ColumnIdentifierError:
-                if ':' in c:
-                    a, b = c.split(':', 1)
-                elif '-' in c:
-                    a, b = c.split('-', 1)
-                else:
-                    # Ignore unknown columns.
-                    continue
+        for identifier in excluded_columns.split(','):
+            # -C is always tolerant of unknown column names, but a malformed range is still a user error.
+            excludes.extend(
+                _resolve_column_identifier(
+                    column_names=column_names,
+                    identifier=identifier,
+                    column_offset=column_offset,
+                    ignore_unknown_columns=True,
+                    ignore_invalid_range=False,
+                )
+            )
 
-                try:
-                    a = int(a) if a else 1
-                    b = int(b) + 1 if b else len(column_names)
-                except ValueError:
-                    raise ColumnIdentifierError(
-                        "Invalid range %s. Ranges must be two integers separated by a - or : character." % c)
-
-                for x in range(a, b):
-                    excludes.append(match_column_identifier(column_names, x, column_offset))
-
-    return [c for c in columns if c not in excludes]
+    return [index for index in columns if index not in excludes]
 
 
 def parse_list(pairs):

--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -428,6 +428,7 @@ class CSVKitUtility:
             column_names,
             column_offset,
             getattr(self.args, 'not_columns', None),
+            ignore_unknown_columns=getattr(self.args, 'ignore_unknown_columns', False),
         )
 
         return rows, column_names, column_ids
@@ -512,7 +513,7 @@ def match_column_identifier(column_names, c, column_offset=1):
     return c
 
 
-def parse_column_identifiers(ids, column_names, column_offset=1, excluded_columns=None):
+def parse_column_identifiers(ids, column_names, column_offset=1, excluded_columns=None, ignore_unknown_columns=False):
     """
     Parse a comma-separated list of column indices AND/OR names into a list of integer indices.
     Ranges of integers can be specified with two integers separated by a '-' or ':' character.
@@ -537,6 +538,8 @@ def parse_column_identifiers(ids, column_names, column_offset=1, excluded_column
                 elif '-' in c:
                     a, b = c.split('-', 1)
                 else:
+                    if ignore_unknown_columns:
+                        continue
                     raise
 
                 try:
@@ -547,7 +550,12 @@ def parse_column_identifiers(ids, column_names, column_offset=1, excluded_column
                         "Invalid range %s. Ranges must be two integers separated by a - or : character.")
 
                 for x in range(a, b):
-                    columns.append(match_column_identifier(column_names, x, column_offset))
+                    try:
+                        columns.append(match_column_identifier(column_names, x, column_offset))
+                    except ColumnIdentifierError:
+                        if ignore_unknown_columns:
+                            continue
+                        raise
     else:
         columns = range(len(column_names))
 

--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -546,8 +546,10 @@ def parse_column_identifiers(ids, column_names, column_offset=1, excluded_column
                     a = int(a) if a else 1
                     b = int(b) + 1 if b else len(column_names) + 1
                 except ValueError:
+                    if ignore_unknown_columns:
+                        continue
                     raise ColumnIdentifierError(
-                        "Invalid range %s. Ranges must be two integers separated by a - or : character.")
+                        "Invalid range %s. Ranges must be two integers separated by a - or : character." % c)
 
                 for x in range(a, b):
                     try:
@@ -579,7 +581,7 @@ def parse_column_identifiers(ids, column_names, column_offset=1, excluded_column
                     b = int(b) + 1 if b else len(column_names)
                 except ValueError:
                     raise ColumnIdentifierError(
-                        "Invalid range %s. Ranges must be two integers separated by a - or : character.")
+                        "Invalid range %s. Ranges must be two integers separated by a - or : character." % c)
 
                 for x in range(a, b):
                     excludes.append(match_column_identifier(column_names, x, column_offset))

--- a/csvkit/utilities/csvcut.py
+++ b/csvkit/utilities/csvcut.py
@@ -35,6 +35,10 @@ class CSVCut(CSVKitUtility):
         self.argparser.add_argument(
             '-x', '--delete-empty-rows', dest='delete_empty', action='store_true',
             help='After cutting, delete rows which are completely empty.')
+        self.argparser.add_argument(
+            '--ignore-unknown-columns', dest='ignore_unknown_columns', action='store_true',
+            help='Ignore identifiers in --columns (-c) that do not match a column in the input, '
+                 'instead of erroring.')
 
     def main(self):
         if self.args.names_only:

--- a/docs/scripts/csvcut.rst
+++ b/docs/scripts/csvcut.rst
@@ -36,6 +36,9 @@ Filters and truncates CSV files. Like the Unix "cut" command, but for tabular da
                            columns. Ignores unknown columns.
      -x, --delete-empty-rows
                            After cutting, delete rows which are completely empty.
+     --ignore-unknown-columns
+                           Ignore identifiers in --columns (-c) that do not match
+                           a column in the input, instead of erroring.
 
 See also: :doc:`../common_arguments`.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,26 @@ class TestCli(unittest.TestCase):
         with self.assertRaises(ColumnIdentifierError):
             parse_column_identifiers('id,no-pe,i_work_here', self.headers)
 
+    def test_exclude_open_ended_range(self):
+        # An open-ended exclusion range reaches the last column.
+        self.assertEqual(
+            [0, 1, 2, 3, 4],
+            parse_column_identifiers(None, self.headers, excluded_columns='6-'),
+        )
+
+    def test_exclude_ignores_unknown_names_but_reports_invalid_ranges(self):
+        # An unknown bare name is skipped (long-standing -C tolerance)...
+        self.assertEqual(
+            [0, 1, 2, 3, 4, 5, 6],
+            parse_column_identifiers(None, self.headers, excluded_columns='nope'),
+        )
+        # ...but a malformed range is a user error, even for -C.
+        with self.assertRaises(ColumnIdentifierError):
+            parse_column_identifiers(None, self.headers, excluded_columns='no-pe')
+        # ...as is a range that references a nonexistent column.
+        with self.assertRaises(ColumnIdentifierError):
+            parse_column_identifiers(None, self.headers, excluded_columns='6-99')
+
     def test_range_notation_open_ended(self):
         self.assertEqual([0, 1, 2], parse_column_identifiers(':3', self.headers))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import unittest
 
-from csvkit.cli import match_column_identifier, parse_column_identifiers
+from csvkit.cli import ColumnIdentifierError, match_column_identifier, parse_column_identifiers
 
 
 class TestCli(unittest.TestCase):
@@ -53,6 +53,14 @@ class TestCli(unittest.TestCase):
             [],
             parse_column_identifiers('nope,missing', self.headers, ignore_unknown_columns=True),
         )
+        # An unknown identifier containing '-' or ':' is skipped too, not parsed as a range.
+        self.assertEqual(
+            [0, 2],
+            parse_column_identifiers('id,no-pe,i_work_here', self.headers, ignore_unknown_columns=True),
+        )
+        # Without the flag, the same input still raises.
+        with self.assertRaises(ColumnIdentifierError):
+            parse_column_identifiers('id,no-pe,i_work_here', self.headers)
 
     def test_range_notation_open_ended(self):
         self.assertEqual([0, 1, 2], parse_column_identifiers(':3', self.headers))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,16 @@ class TestCli(unittest.TestCase):
         self.assertEqual([4, 3, 5], parse_column_identifiers(
             'more-header-values,3,stuff', self.headers, column_offset=0))
 
+    def test_ignore_unknown_columns(self):
+        self.assertEqual(
+            [0, 2],
+            parse_column_identifiers('id,nope,i_work_here', self.headers, ignore_unknown_columns=True),
+        )
+        self.assertEqual(
+            [],
+            parse_column_identifiers('nope,missing', self.headers, ignore_unknown_columns=True),
+        )
+
     def test_range_notation_open_ended(self):
         self.assertEqual([0, 1, 2], parse_column_identifiers(':3', self.headers))
 

--- a/tests/test_utilities/test_csvcut.py
+++ b/tests/test_utilities/test_csvcut.py
@@ -61,6 +61,12 @@ class TestCSVCut(CSVKitTestCase, ColumnsTests, EmptyFileTests, NamesTests):
             ['2', '3'],
         ])
 
+    def test_ignore_unknown_columns(self):
+        self.assertRows(['-c', 'a,nope,c', '--ignore-unknown-columns', 'examples/dummy.csv'], [
+            ['a', 'c'],
+            ['1', '3'],
+        ])
+
     def test_include_and_exclude(self):
         self.assertRows(['-c', '1,3', '-C', '3', 'examples/dummy.csv'], [
             ['a'],


### PR DESCRIPTION
Closes #1288. Adds an `--ignore-unknown-columns` flag to `csvcut` that skips identifiers in `-c/--columns` which do not match a column in the input, mirroring the existing tolerant behavior of `-C/--not-columns`. As @jpmckinney said in the issue: "Sounds good, I would accept a PR." Default behavior is unchanged.