### PR TITLE
Suggest --snifflimit 0 for non-seekable input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 
+-  feat: Suggest :code:`--snifflimit 0` when standard input is not seekable.
 -  feat: :doc:`/scripts/csvcut` adds an :code:`--ignore-unknown-columns` option to skip identifiers in :code:`-c/--columns` that do not match a column in the input.
 -  feat: :doc:`/scripts/csvclean` adds a :code:`--remove-empty-columns` option to remove empty columns from standard output.
 -  feat: :doc:`/scripts/in2csv` guesses the ``ndjson`` format for files with :code:`.ndjson`, :code:`.jsonl` and :code:`.jl` extensions.

--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -6,6 +6,7 @@ import csv
 import datetime
 import decimal
 import gzip
+import io
 import itertools
 import lzma
 import os
@@ -346,6 +347,8 @@ class CSVKitUtility:
                     )
                 else:
                     sys.stderr.write(f'{t.__name__}: {str(value)}\n')
+                    if t == io.UnsupportedOperation and str(value) == 'underlying stream is not seekable':
+                        sys.stderr.write('Try setting --snifflimit 0.\n')
 
         sys.excepthook = handler
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,60 @@
+import io
+import sys
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
-from csvkit.cli import ColumnIdentifierError, match_column_identifier, parse_column_identifiers
+from csvkit.cli import ColumnIdentifierError, CSVKitUtility, match_column_identifier, parse_column_identifiers
 
 
 class TestCli(unittest.TestCase):
 
     def setUp(self):
         self.headers = ['id', 'name', 'i_work_here', '1', 'more-header-values', 'stuff', 'blueberry']
+
+    def install_exception_handler(self, verbose=False):
+        original = sys.excepthook
+        self.addCleanup(setattr, sys, 'excepthook', original)
+        utility = object.__new__(CSVKitUtility)
+        utility.args = SimpleNamespace(verbose=verbose, encoding='utf-8')
+        utility._install_exception_handler()
+        return sys.excepthook
+
+    def test_exception_handler_suggests_snifflimit_for_non_seekable_stream(self):
+        handler = self.install_exception_handler()
+        with mock.patch('sys.stderr', new_callable=io.StringIO) as stderr:
+            handler(io.UnsupportedOperation, io.UnsupportedOperation('underlying stream is not seekable'), None)
+
+        self.assertIn('UnsupportedOperation: underlying stream is not seekable', stderr.getvalue())
+        self.assertIn('--snifflimit 0', stderr.getvalue())
+
+    def test_exception_handler_does_not_suggest_snifflimit_for_other_unsupported_operation(self):
+        handler = self.install_exception_handler()
+        with mock.patch('sys.stderr', new_callable=io.StringIO) as stderr:
+            handler(io.UnsupportedOperation, io.UnsupportedOperation('other operation'), None)
+
+        self.assertEqual('UnsupportedOperation: other operation\n', stderr.getvalue())
+
+    def test_exception_handler_verbose_uses_default_hook(self):
+        handler = self.install_exception_handler(verbose=True)
+        traceback = object()
+        error = io.UnsupportedOperation('underlying stream is not seekable')
+        with mock.patch.object(sys, '__excepthook__') as default_hook:
+            handler(io.UnsupportedOperation, error, traceback)
+
+        default_hook.assert_called_once_with(io.UnsupportedOperation, error, traceback)
+
+    def test_exception_handler_preserves_unicode_decode_message(self):
+        handler = self.install_exception_handler()
+        error = UnicodeDecodeError('utf-8', b'\xff', 0, 1, 'invalid start byte')
+        with mock.patch('sys.stderr', new_callable=io.StringIO) as stderr:
+            handler(UnicodeDecodeError, error, None)
+
+        self.assertEqual(
+            'Your file is not "utf-8" encoded. Please specify the correct encoding with the --encoding flag.'
+            ' Use the -v flag to see the complete error.\n',
+            stderr.getvalue(),
+        )
 
     def test_match_column_identifier_string(self):
         self.assertEqual(2, match_column_identifier(self.headers, 'i_work_here'))


### PR DESCRIPTION
## Summary

- detect the exact `io.UnsupportedOperation` raised when dialect sniffing tries to rewind non-seekable standard input
- suggest the existing `--snifflimit 0` workaround without changing other exception output
- add positive and negative regression coverage and document the change in the Unreleased changelog

Fixes #1344.

## Validation

- focused CLI tests: 13 passed on the exact upstream base and patch
- full suite: 359 passed plus 31 subtests on the exact upstream base and patch
- flake8, isort, and check-manifest passed on the exact upstream base and patch
- four direct exception-handler self-tests, Python AST checks, and `git diff --check` passed in the publication worktree
- the current publication environment could not recollect pytest because `agate` is not installed; no dependencies were installed for this submission

## AI assistance disclosure

This change was prepared and tested with OpenAI Codex. It is intentionally opened as a Draft for maintainer review. No automated issue/PR comments or Ready transition will be made.