### PR TITLE
fix: serialize array-valued GeoJSON properties as JSON

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Unreleased
 -  feat: :doc:`/scripts/csvclean` adds a :code:`--remove-empty-columns` option to remove empty columns from standard output.
 -  feat: :doc:`/scripts/in2csv` guesses the ``ndjson`` format for files with :code:`.ndjson`, :code:`.jsonl` and :code:`.jl` extensions.
 -  fix: :code:`-C/--not-columns` now excludes the last column of an open-ended range (e.g. :code:`2-`).
+-  fix: :doc:`/scripts/in2csv` with :code:`--format geojson` serializes array-valued properties as JSON, like object-valued properties, instead of as a Python ``repr``.
 
 2.2.0 - December 15, 2025
 -------------------------

--- a/csvkit/convert/geojs.py
+++ b/csvkit/convert/geojs.py
@@ -64,7 +64,7 @@ def geojson2csv(f, key=None, **kwargs):
 
         for field in property_fields:
             value = properties.get(field)
-            if isinstance(value, OrderedDict):
+            if isinstance(value, (OrderedDict, list)):
                 value = json.dumps(value)
             row.append(value)
 

--- a/tests/test_utilities/test_in2csv.py
+++ b/tests/test_utilities/test_in2csv.py
@@ -229,6 +229,19 @@ class TestIn2CSV(CSVKitTestCase, EmptyFileTests):
 
         input_file.close()
 
+    def test_geojson_array_property(self):
+        input_file = io.BytesIO(
+            b'{"type": "FeatureCollection", "features": [{"geometry": null, "properties": '
+            b'{"tags": ["a", "b"], "obj": {"k": "v"}}}]}')
+
+        with stdin_as_string(input_file):
+            self.assertLines(['-f', 'geojson'], [
+                'id,tags,obj,geojson,type,longitude,latitude',
+                ',"[""a"", ""b""]","{""k"": ""v""}",null,,,',
+            ])
+
+        input_file.close()
+
     def test_json_no_inference(self):
         input_file = io.BytesIO(b'[{"a": 1, "b": 2, "c": 3}]')
 


### PR DESCRIPTION
### The bug

`in2csv --format geojson` serializes an **object**-valued GeoJSON property as JSON, but an **array**-valued property is emitted as a Python `repr` — invalid, non-round-trippable JSON. Both container types appear side by side in the same row:

```
{"type":"FeatureCollection","features":[{"type":"Feature","id":1,
 "properties":{"name":"Central Park","categories":["park","landmark"],"opening_hours":{"mon":"6-1"}},
 "geometry":{"type":"Point","coordinates":[-73.965,40.782]}}]}
```

```
id,name,categories,opening_hours,...
1,Central Park,"['park', 'landmark']","{""mon"": ""6-1""}",...
```

- `categories` (array) → `['park', 'landmark']` — Python repr, single quotes, **not valid JSON**
- `opening_hours` (object) → `{"mon": "6-1"}` — JSON

Per GeoJSON (RFC 7946), a Feature's `properties` is a JSON object whose values may be arrays (tags, categories, times…), so array-valued properties are ordinary input.

### Root cause

`csvkit/convert/geojs.py`:

```python
value = properties.get(field)
if isinstance(value, OrderedDict):   # only objects get json.dumps; arrays fall through to str()/repr
    value = json.dumps(value)
```

That `OrderedDict` check was added specifically to stop emitting Python repr (CHANGELOG: *"in2csv with `--format geojson` prints a JSON object instead of `OrderedDict([(...)])`"*). Arrays are the other half of the same intent and were left out.

### The fix

```python
if isinstance(value, (OrderedDict, list)):
    value = json.dumps(value)
```

### Verification

- The repro now emits `["park", "landmark"]`; the object column is unchanged.
- Added `test_geojson_array_property` to `tests/test_utilities/test_in2csv.py`; it fails on `master` (the cell is the repr) and passes with the fix.
- `tests/test_convert/` + `tests/test_utilities/test_in2csv.py` → 68 passed. `flake8` / `isort` clean. CHANGELOG entry added.

Not a duplicate — no open issue/PR touches geojson input conversion (the nearby closed #827 was about `csvjson` output, the opposite direction).

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
