### PR TITLE
Name the method in CSVKitUtility.main's NotImplementedError

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -154,7 +154,7 @@ class CSVKitUtility:
 
         Should be overriden by individual utilities and explicitly called by the executing script.
         """
-        raise NotImplementedError(' must be provided by each subclass of CSVKitUtility.')
+        raise NotImplementedError('main must be provided by each subclass of CSVKitUtility.')
 
     def _init_common_parser(self):
         """


### PR DESCRIPTION
`CSVKitUtility.main` raises a `NotImplementedError` whose message is missing the method name and begins with a stray space:

```python
raise NotImplementedError(' must be provided by each subclass of CSVKitUtility.')
```

So a subclass author who forgets to implement `main()` gets:

```
NotImplementedError:  must be provided by each subclass of CSVKitUtility.
```

The sibling `add_arguments` a few lines above names itself correctly, which shows the intended form:

```python
raise NotImplementedError('add_arguments must be provided by each subclass of CSVKitUtility.')
```

This adds the missing `main` so both messages match.

No CHANGELOG entry, since this is an internal error message rather than a user-facing script change — happy to add one if you'd prefer. `tests/test_cli.py` passes locally and `flake8` is clean.
